### PR TITLE
#121 Work in progress: disable zoom from identify task, but preserve highligh

### DIFF
--- a/infopanel.js
+++ b/infopanel.js
@@ -237,10 +237,14 @@ async function queryInfoPanel(event = false, results, i) {
                 const relatedFeatures = results[i - 1].attributes.relatedFeatures
 
                 const addFeature = async (relatedFeatures) => {
-                    console.log(results[i - 1].attributes.relatedFeatures);
+                    return results[i - 1].attributes.relatedFeatures;
 
                 }
-                await addFeature(relatedFeatures);
+                await addFeature(relatedFeatures)
+                    .then(function (res) {
+                        console.log(res);
+
+                    });
 
 
             } else if (results[i - 1].attributes.layerName === 'Coastal Construction Control Lines') {

--- a/infopanel.js
+++ b/infopanel.js
@@ -233,7 +233,7 @@ async function queryInfoPanel(event = false, results, i) {
                 // );
 
                 // const relatedFeatures = await results[i - 1].attributes.relatedFeatures;
-                console.log(results[i - 1].attributes.relatedFeatures);
+                console.log(results[i - 1].attributes);
                 const relatedFeatures = results[i - 1].attributes.relatedFeatures
 
                 const addFeature = async (relatedFeatures) => {

--- a/infopanel.js
+++ b/infopanel.js
@@ -223,11 +223,17 @@ async function queryInfoPanel(event = false, results, i) {
                 });
 
             } else if (results[i - 1].attributes.layerName === 'base_and_survey.sde.pls_ptp_Mar2019_3857') {
+                console.log(results[i - 1].attributes);
+
                 $('#informationdiv').append('<p style= "font-size: 15px"><b>New CCR Layer</b></p>' +
                     '<b>BLMID: </b>' + results[i - 1].attributes.blmid + '<br>' +
                     '<b>Quad Name: </b>' + results[i - 1].attributes.tile_name + '<br>' +
                     '<b>Quad Number: </b>' + results[i - 1].attributes.quad_num + '<br>'
                 );
+                results[i - 1].attributes.relatedFeatures.map(docnum => {
+
+                    $('#informationdiv').append('<b>PDF: </b><a target="_blank" href=https://ftp.labins.org/ccpXX/bydocno_pdf/' + docnumWithLeadingZeroes + '.pdf>afile.pdf</a><br>');
+                })
             } else if (results[i - 1].attributes.layerName === 'Coastal Construction Control Lines') {
                 $('#informationdiv').append('<p style= "font-size: 15px"><b>Coastal Construction Control Lines</b></p>' +
                     '<b>County: </b>' + results[i - 1].attributes.COUNTY + '<br>' +

--- a/infopanel.js
+++ b/infopanel.js
@@ -1,5 +1,10 @@
 async function queryInfoPanel(event = false, results, i) {
 
+    console.log({
+        results
+    });
+
+
     if (event.mapPoint) {
         $('#informationdiv').append('<a target="_blank" href=http://maps.google.com/maps?q=&layer=c&cbll=' + event.mapPoint.latitude + ',' + event.mapPoint.longitude + '>Google Street View&nbsp</a> <span class="esri-icon-description" data-toggle="tooltip" data-placement="top" title="Please note: if not clicked where there are streets, no imagery will be returned."></span><br><br>');
     } else {
@@ -216,6 +221,9 @@ async function queryInfoPanel(event = false, results, i) {
                 tifFiles.map(fileName => {
                     $('#informationdiv').append('<b>Image: </b><a target="_blank" href=' + fileName + '>' + fileName.slice(-12, -4) + '.tif</a><br>');
                 });
+
+            } else if (results[i - 1].attributes.layerName === 'New Certified Corner Records') {
+                console.log('hey shit')
 
             } else if (results[i - 1].attributes.layerName === 'Coastal Construction Control Lines') {
                 $('#informationdiv').append('<p style= "font-size: 15px"><b>Coastal Construction Control Lines</b></p>' +

--- a/infopanel.js
+++ b/infopanel.js
@@ -222,9 +222,12 @@ async function queryInfoPanel(event = false, results, i) {
                     $('#informationdiv').append('<b>Image: </b><a target="_blank" href=' + fileName + '>' + fileName.slice(-12, -4) + '.tif</a><br>');
                 });
 
-            } else if (results[i - 1].attributes.layerName === 'New Certified Corner Records') {
-                console.log('hey shit')
-
+            } else if (results[i - 1].attributes.layerName === 'base_and_survey.sde.pls_ptp_Mar2019_3857') {
+                $('#informationdiv').append('<p style= "font-size: 15px"><b>New CCR Layer</b></p>' +
+                    '<b>BLMID: </b>' + results[i - 1].attributes.blmid + '<br>' +
+                    '<b>Quad Name: </b>' + results[i - 1].attributes.tile_name + '<br>' +
+                    '<b>Quad Number: </b>' + results[i - 1].attributes.quad_num + '<br>'
+                );
             } else if (results[i - 1].attributes.layerName === 'Coastal Construction Control Lines') {
                 $('#informationdiv').append('<p style= "font-size: 15px"><b>Coastal Construction Control Lines</b></p>' +
                     '<b>County: </b>' + results[i - 1].attributes.COUNTY + '<br>' +

--- a/infopanel.js
+++ b/infopanel.js
@@ -237,7 +237,6 @@ async function queryInfoPanel(event = false, results, i) {
                 const relatedFeatures = results[i - 1].attributes.relatedFeatures
 
                 const addFeature = async (relatedFeatures) => {
-                    console.log('fuuuuuck');
                     console.log(results[i - 1].attributes.relatedFeatures);
 
                 }

--- a/infopanel.js
+++ b/infopanel.js
@@ -225,15 +225,25 @@ async function queryInfoPanel(event = false, results, i) {
             } else if (results[i - 1].attributes.layerName === 'base_and_survey.sde.pls_ptp_Mar2019_3857') {
                 console.log(results[i - 1].attributes);
 
-                $('#informationdiv').append('<p style= "font-size: 15px"><b>New CCR Layer</b></p>' +
-                    '<b>BLMID: </b>' + results[i - 1].attributes.blmid + '<br>' +
-                    '<b>Quad Name: </b>' + results[i - 1].attributes.tile_name + '<br>' +
-                    '<b>Quad Number: </b>' + results[i - 1].attributes.quad_num + '<br>'
-                );
-                results[i - 1].attributes.relatedFeatures.map(docnum => {
 
-                    $('#informationdiv').append('<b>PDF: </b><a target="_blank" href=https://ftp.labins.org/ccpXX/bydocno_pdf/' + docnumWithLeadingZeroes + '.pdf>afile.pdf</a><br>');
-                })
+                // $('#informationdiv').append('<p style= "font-size: 15px"><b>New CCR Layer</b></p>' +
+                //     '<b>BLMID: </b>' + results[i - 1].attributes.blmid + '<br>' +
+                //     '<b>Quad Name: </b>' + results[i - 1].attributes.tile_name + '<br>' +
+                //     '<b>Quad Number: </b>' + results[i - 1].attributes.quad_num + '<br>'
+                // );
+
+                // const relatedFeatures = await results[i - 1].attributes.relatedFeatures;
+                console.log(results[i - 1].attributes.relatedFeatures);
+                const relatedFeatures = results[i - 1].attributes.relatedFeatures
+
+                const addFeature = async (relatedFeatures) => {
+                    console.log('fuuuuuck');
+                    console.log(results[i - 1].attributes.relatedFeatures);
+
+                }
+                await addFeature(relatedFeatures);
+
+
             } else if (results[i - 1].attributes.layerName === 'Coastal Construction Control Lines') {
                 $('#informationdiv').append('<p style= "font-size: 15px"><b>Coastal Construction Control Lines</b></p>' +
                     '<b>County: </b>' + results[i - 1].attributes.COUNTY + '<br>' +

--- a/script.js
+++ b/script.js
@@ -1373,30 +1373,6 @@ require([
   }
 
 
-  const queryRelatedFeatures = async (oid, layer) => {
-    const ccp_rquery = {
-      outFields: ["DOCNUM"],
-      relationshipId: 0,
-      objectIds: oid
-    };
-
-    const relatedFeaturesArr = [];
-
-    layer.queryRelatedFeatures(ccp_rquery).then(function (result) {
-      console.log(result);
-
-      if (result[oid]) {
-        result[oid].features.forEach(function (feature) {
-          console.log('CCP Related features:', feature.attributes);
-          relatedFeaturesArr.push(feature.attributes);
-        });
-      }
-      return relatedFeaturesArr;
-
-    });
-  }
-
-
   //////////////////////////////////
   //// Search Widget Text Search ///
   //////////////////////////////////

--- a/script.js
+++ b/script.js
@@ -1123,13 +1123,22 @@ require([
 
             // push each feature to the infoPanelData
             for (feature of identify.results) {
-              console.log(feature);
+              console.log({
+                feature: feature
+              });
 
               feature.feature.attributes.layerName = feature.layerName;
               let result = feature.feature.attributes
 
+              if (result.layerName === 'base_and_survey.sde.pls_ptp_Mar2019_3857') {
+                // this is where we will query the related features
+                queryRelatedFeatures(result.objectid, newCCRLayer);
+              }
+
               // make sure only certified corners with images are identified
-              if (result.layerName !== 'Certified Corners' || result.is_image == 'Y') {
+              if ((result.layerName !== 'Certified Corners') || (result.is_image == 'Y') || (result.layerName !== 'base_and_survey.sde.pls_ptp_Mar2019_3857')) {
+                console.log(result.layerName);
+
                 await infoPanelData.push(feature.feature);
               }
             }
@@ -1342,8 +1351,20 @@ require([
   }
 
 
-  function queryRelatedFeatures() {
-    return true;
+  function queryRelatedFeatures(oid, layer) {
+    ccp_rquery = {
+      outFields: ["DOCNUM"],
+      relationshipId: 0,
+      objectIds: oid
+    };
+
+    layer.queryRelatedFeatures(ccp_rquery).then(function (result) {
+      if (result[oid]) {
+        result[oid].features.forEach(function (feature) {
+          console.log('CCP Related features:', feature.attributes);
+        });
+      }
+    });
   }
 
   //////////////////////////////////

--- a/script.js
+++ b/script.js
@@ -994,7 +994,7 @@ require([
       }
     }
 
-    const layersArr = [ /*GNISLayer, */ /*countyBoundariesLayer, */ labinsLayer, /* swfwmdLayer , CCCLLayer, townshipRangeSectionLayer, */ newCCRLayer];
+    const layersArr = [ /*GNISLayer, */ /*countyBoundariesLayer, labinsLayer, swfwmdLayer , CCCLLayer, townshipRangeSectionLayer, */ newCCRLayer];
 
     // wait for all services to be checked in the layersArr
     await checkServices(layersArr);
@@ -1120,7 +1120,6 @@ require([
 
             });
 
-
             // push each feature to the infoPanelData
             for (feature of identify.results) {
               console.log({
@@ -1132,7 +1131,30 @@ require([
 
               if (result.layerName === 'base_and_survey.sde.pls_ptp_Mar2019_3857') {
                 // this is where we will query the related features
-                queryRelatedFeatures(result.objectid, newCCRLayer);
+                // queryRelatedFeatures(result.objectid, newCCRLayer);
+
+                // const relatedFeaturesResults = await queryRelatedFeatures(120280, newCCRLayer);
+                // console.log(relatedFeaturesResults);
+
+                const ccp_rquery = {
+                  outFields: ["DOCNUM"],
+                  relationshipId: 0,
+                  objectIds: result.objectid
+                };
+
+                result.relatedFeatures = [];
+
+                newCCRLayer.queryRelatedFeatures(ccp_rquery).then(function (res) {
+                  console.log(res);
+
+                  if (res[result.objectid]) {
+                    res[result.objectid].features.forEach(function (feature) {
+                      console.log('CCP Related features:', feature.attributes);
+                      result.relatedFeatures.push(feature.attributes);
+                    });
+                  }
+                });
+
               }
 
               // make sure only certified corners with images are identified
@@ -1351,21 +1373,29 @@ require([
   }
 
 
-  function queryRelatedFeatures(oid, layer) {
-    ccp_rquery = {
+  const queryRelatedFeatures = async (oid, layer) => {
+    const ccp_rquery = {
       outFields: ["DOCNUM"],
       relationshipId: 0,
       objectIds: oid
     };
 
+    const relatedFeaturesArr = [];
+
     layer.queryRelatedFeatures(ccp_rquery).then(function (result) {
+      console.log(result);
+
       if (result[oid]) {
         result[oid].features.forEach(function (feature) {
           console.log('CCP Related features:', feature.attributes);
+          relatedFeaturesArr.push(feature.attributes);
         });
       }
+      return relatedFeaturesArr;
+
     });
   }
+
 
   //////////////////////////////////
   //// Search Widget Text Search ///

--- a/script.js
+++ b/script.js
@@ -283,21 +283,6 @@ require([
     popupEnabled: false
   });
 
-  const oid = 120280;
-  ccp_rquery = {
-    outFields: ["DOCNUM"],
-    relationshipId: 0,
-    objectIds: oid
-  };
-
-  newCCRLayer.queryRelatedFeatures(ccp_rquery).then(function (result) {
-    if (result[oid]) {
-      result[oid].features.forEach(function (feature) {
-        // console.log('CCP Related features:', feature.attributes);
-      });
-    }
-  });
-
   var CCCLURL = "https://ca.dep.state.fl.us/arcgis/rest/services/OpenData/COASTAL_ENV_PERM/MapServer/2"
   var CCCLLayer = new FeatureLayer({
     url: CCCLURL,
@@ -1354,6 +1339,11 @@ require([
         }
       }
     }
+  }
+
+
+  function queryRelatedFeatures() {
+    return true;
   }
 
   //////////////////////////////////

--- a/script.js
+++ b/script.js
@@ -1119,6 +1119,8 @@ require([
 
             // push each feature to the infoPanelData
             for (feature of identify.results) {
+              console.log(feature);
+
               feature.feature.attributes.layerName = feature.layerName;
               let result = feature.feature.attributes
 
@@ -1131,6 +1133,10 @@ require([
         }
       }
       if (infoPanelData.length > 0) {
+        console.log({
+          infoPanelData
+        });
+
         await queryInfoPanel(event, infoPanelData, 1);
         togglePanel();
         await goToFeature(infoPanelData[0]);

--- a/script.js
+++ b/script.js
@@ -274,6 +274,19 @@ require([
     popupEnabled: false
   });
 
+  const newCCRURL = "https://maps.freac.fsu.edu/arcgis/rest/services/LABINS/ccp_pilot/MapServer/";
+  const newCCRLayer = new MapImageLayer({
+    url: newCCRURL,
+    minScale: minimumDrawScale,
+    title: "New Certified Corner Records",
+    sublayers: [{
+      id: 0,
+      title: "New Certified Corner Records",
+      visible: true,
+      popupEnabled: false
+    }]
+  })
+
   var CCCLURL = "https://ca.dep.state.fl.us/arcgis/rest/services/OpenData/COASTAL_ENV_PERM/MapServer/"
   var CCCLLayer = new MapImageLayer({
     url: CCCLURL,
@@ -985,7 +998,7 @@ require([
       }
     }
 
-    const layersArr = [ /*GNISLayer, */ countyBoundariesLayer, labinsLayer, swfwmdLayer, CCCLLayer, townshipRangeSectionLayer];
+    const layersArr = [ /*GNISLayer, */ /*countyBoundariesLayer, labinsLayer, swfwmdLayer, CCCLLayer, townshipRangeSectionLayer, */ newCCRLayer];
 
     // wait for all services to be checked in the layersArr
     await checkServices(layersArr);
@@ -1084,6 +1097,10 @@ require([
 
       // look inside of layerList layers
       let layers = layerList.operationalItems.items
+      console.log({
+        layers
+      });
+
 
       // loop through layers
       for (layer of layers) {
@@ -1094,6 +1111,8 @@ require([
 
           // if there are visible layers returned
           if (visibleLayers.length > 0) {
+            console.log('visible layers is greater than 0');
+
             const task = new IdentifyTask(layer.layer.url)
             const params = await setIdentifyParameters(visibleLayers, "click", event);
             const identify = await executeIdentifyTask(task, params);
@@ -1145,10 +1164,16 @@ require([
   async function checkVisibleLayers(service) {
     let visibleLayerIds = [];
     if (service.visible == true) {
+      console.log('is currently visible');
+
       // find the currently visible layers/sublayers
       for (sublayer of service.children.items) {
         // if sublayer is visible, add to visibleLayerIds array
         if (sublayer.visible) {
+          console.log({
+            sublayer
+          });
+
           visibleLayerIds.push(sublayer.layer.id);
         }
       }

--- a/script.js
+++ b/script.js
@@ -1093,9 +1093,9 @@ require([
 
       // look inside of layerList layers
       let layers = layerList.operationalItems.items
-      console.log({
-        layers
-      });
+      // console.log({
+      //   layers
+      // });
 
 
       // loop through layers
@@ -1107,24 +1107,24 @@ require([
 
           // if there are visible layers returned
           if (visibleLayers.length > 0) {
-            console.log('visible layers is greater than 0');
-            console.log(visibleLayers);
+            // console.log('visible layers is greater than 0');
+            // console.log(visibleLayers);
 
 
             const task = new IdentifyTask(layer.layer.url)
             const params = await setIdentifyParameters(visibleLayers, "click", event);
             const identify = await executeIdentifyTask(task, params);
 
-            console.log({
-              layerurl: layer.layer.url,
+            // console.log({
+            //   layerurl: layer.layer.url,
 
-            });
+            // });
 
             // push each feature to the infoPanelData
             for (feature of identify.results) {
-              console.log({
-                feature: feature
-              });
+              // console.log({
+              //   feature: feature
+              // });
 
               feature.feature.attributes.layerName = feature.layerName;
               let result = feature.feature.attributes
@@ -1145,12 +1145,12 @@ require([
                 result.relatedFeatures = [];
 
                 newCCRLayer.queryRelatedFeatures(ccp_rquery).then(function (res) {
-                  console.log(res);
+                  // console.log(res);
 
                   if (res[result.objectid]) {
-                    res[result.objectid].features.forEach(function (feature) {
-                      console.log('CCP Related features:', feature.attributes);
-                      result.relatedFeatures.push(feature.attributes);
+                    res[result.objectid].features.forEach(async function (feature) {
+                      console.log('CCP Related features:', feature.attributes.docnum);
+                      await result.relatedFeatures.push(feature.attributes.docnum);
                     });
                   }
                 });
@@ -1159,7 +1159,7 @@ require([
 
               // make sure only certified corners with images are identified
               if ((result.layerName !== 'Certified Corners') || (result.is_image == 'Y') || (result.layerName !== 'base_and_survey.sde.pls_ptp_Mar2019_3857')) {
-                console.log(result.layerName);
+                // console.log(result.layerName);
 
                 await infoPanelData.push(feature.feature);
               }

--- a/script.js
+++ b/script.js
@@ -1142,7 +1142,7 @@ require([
                   objectIds: result.objectid
                 };
 
-                result.relatedFeatures = [];
+                result.relatedFeatures = new Array();
 
                 newCCRLayer.queryRelatedFeatures(ccp_rquery).then(function (res) {
                   // console.log(res);


### PR DESCRIPTION
Created this PR to better track progress of this fix. 

Currently when a user clicks on feature on the map, the response is a zoom and highlight of the feature.

The zoom and highlight were coupled together in one function. I decoupled this logic and made a highlightFeature() function to only highlight the feature.

To be completed: 
This has been broken for a while, but I think this is a good opportunity to fix. The highlight of a polyline does not currently work. Trying to find a solution. 

I think a solution can be found in here (https://developers.arcgis.com/javascript/latest/sample-code/sandbox/index.html?sample=view-hittest) but I think this may require a refactor of a our current code. Maybe I can find another solution that more closely resembled the current codebase. 