### PR TITLE
#121 Work in progress: disable zoom but maintain highlight on identifytask

### DIFF
--- a/infopanel.js
+++ b/infopanel.js
@@ -1,12 +1,3 @@
-const opusData = async (results) => {
-    await $.get("./docs/opus-data/fl_ngs.json", async function (json_data) {
-        const obj = await json_data.find(element => element.properties.pid === results.attributes.pid);
-        if (obj !== undefined) {
-            $('#informationdiv').append('Opus Datasheet: <a target="_blank" href=https://www.labins.org/OPUS/getDatasheet.jsp?PID=' + results.attributes.pid + '>' + results.attributes.pid + '</a><br>');
-        }
-    });
-}
-
 async function queryInfoPanel(event = false, results, i) {
 
     if (event.mapPoint) {
@@ -68,30 +59,20 @@ async function queryInfoPanel(event = false, results, i) {
                     'Datasheet: ' + '<a target="_blank" href=' + results[i - 1].attributes.data_srce + '>' + results[i - 1].attributes.pid + '</a><br>'
                 );
 
-                // https://medium.com/netscape/hacking-it-out-when-cors-wont-let-you-be-great-35f6206cc646
-                // request GeoJson data from USGS remote server
-                var url = 'https://cors-anywhere.herokuapp.com/https://www.ngs.noaa.gov/OPUS/getDatasheet.jsp?PID=' + results[i - 1].attributes.pid;
+                var url = 'https://www.labins.org/OPUS/getDatasheet.jsp?PID=' + results[i - 1].attributes.pid;
 
-                // const opusData = async (results) => {
-                //     console.log(url);
+                const opusData = async (url, results) => {
+                    const response = await fetch(url);
+                    text = await response.text();
 
-                //     $.get(url, async function (response) {
-                //         console.log(response.length);
+                    if (text.length > 428) {
+                        $('#informationdiv').append('OPUS Datasheet: ' + '<a target="_blank" href=https://www.labins.org/OPUS/getDatasheet.jsp?PID=' + results.attributes.pid + '>' + results.attributes.pid + '</a> <br>');
+                    } else {
+                        // no data returned
+                    }
+                }
 
-                //         if (response.length > 428) {
-                //             console.log('its greater than 428');
-
-                //             $('#informationdiv').append('OPUS Datasheet: ' + '<a target="_blank" href=https://www.labins.org/OPUS/getDatasheet.jsp?PID=' + results.attributes.pid + '>' + results.attributes.pid + '</a> <br>');
-                //         } else {
-                //             console.log('No data returned for OPUS Datasheet');
-                //         }
-                //     });
-                // }
-
-                // console.log(results);
-
-
-                await opusData(results[i - 1]);
+                await opusData(url, results[i - 1]);
 
             } else if (results[i - 1].attributes.layerName === 'NGS Control Points QueryTask') {
                 $('#informationdiv').append('<p style= "font-size: 15px"><b>NGS Control Points</b></p>' +

--- a/infopanel.js
+++ b/infopanel.js
@@ -73,14 +73,20 @@ async function queryInfoPanel(event = false, results, i) {
                 var url = 'https://cors-anywhere.herokuapp.com/https://www.ngs.noaa.gov/OPUS/getDatasheet.jsp?PID=' + results[i - 1].attributes.pid;
 
                 // const opusData = async (results) => {
-                //     text = await response.text();
-                //     if (text.length > 414) {
-                //         $('#informationdiv').append('OPUS Datasheet: ' + '<a target="_blank" href=https://www.ngs.noaa.gov/OPUS/getDatasheet.jsp?PID=' + results.attributes.pid + '>' + results.attributes.pid + '</a> <br>');
-                //     } else {
-                //         console.log('No data returned for OPUS Datasheet');
-                //     }
+                //     console.log(url);
+
+                //     $.get(url, async function (response) {
+                //         console.log(response.length);
+
+                //         if (response.length > 428) {
+                //             console.log('its greater than 428');
+
+                //             $('#informationdiv').append('OPUS Datasheet: ' + '<a target="_blank" href=https://www.labins.org/OPUS/getDatasheet.jsp?PID=' + results.attributes.pid + '>' + results.attributes.pid + '</a> <br>');
+                //         } else {
+                //             console.log('No data returned for OPUS Datasheet');
+                //         }
+                //     });
                 // }
-                // await opusData(results[i - 1]);
 
                 // console.log(results);
 

--- a/infopanel.js
+++ b/infopanel.js
@@ -2,7 +2,7 @@ const opusData = async (results) => {
     await $.get("./docs/opus-data/fl_ngs.json", async function (json_data) {
         const obj = await json_data.find(element => element.properties.pid === results.attributes.pid);
         if (obj !== undefined) {
-            $('#informationdiv').append('Opus Datasheet: <a target="_blank" href=https://www.ngs.noaa.gov/OPUS/getDatasheet.jsp?PID=' + results.attributes.pid + '>' + results.attributes.pid + '</a><br>');
+            $('#informationdiv').append('Opus Datasheet: <a target="_blank" href=https://www.labins.org/OPUS/getDatasheet.jsp?PID=' + results.attributes.pid + '>' + results.attributes.pid + '</a><br>');
         }
     });
 }

--- a/infopanel.js
+++ b/infopanel.js
@@ -65,7 +65,7 @@ async function queryInfoPanel(event = false, results, i) {
                     const response = await fetch(url);
                     text = await response.text();
 
-                    if (text.length > 428) {
+                    if (text.length > 428) { // response always 200, response length will be > 428 if there is an opus point
                         $('#informationdiv').append('OPUS Datasheet: ' + '<a target="_blank" href=https://www.labins.org/OPUS/getDatasheet.jsp?PID=' + results.attributes.pid + '>' + results.attributes.pid + '</a> <br>');
                     } else {
                         // no data returned

--- a/infopanel.js
+++ b/infopanel.js
@@ -130,7 +130,8 @@ async function queryInfoPanel(event = false, results, i) {
 
                 // }
             } else if (results[i - 1].attributes.layerName === 'Tide Interpolation Points') {
-                var replaceWhitespace = results[i - 1].attributes.tile_name.replace(" ", "%20");
+                var replaceWhitespace = results[i - 1].attributes.tile_name.replace(/\s+/g, "%20");
+
                 $('#informationdiv').append('<p style= "font-size: 15px"><b>Tide Interpolation Points</b></p>' +
                     '<b>Tide Interpolation Points: </b>' + results[i - 1].attributes.iden + '<br>' +
                     '<b>County: </b>' + results[i - 1].attributes.cname + '<br>' +

--- a/script.js
+++ b/script.js
@@ -9,7 +9,6 @@ require([
   "esri/geometry/geometryEngine",
   "esri/geometry/Extent",
   "esri/geometry/Point",
-  "esri/geometry/support/webMercatorUtils",
   "esri/layers/GraphicsLayer",
   "esri/Graphic",
   "esri/tasks/IdentifyTask",
@@ -65,7 +64,6 @@ require([
   geometryEngine,
   Extent,
   Point,
-  webMercatorUtils,
   GraphicsLayer,
   Graphic,
   IdentifyTask,
@@ -1257,29 +1255,13 @@ require([
           featuregeometry: feature
 
         });
-        const paths = [];
-
-        for (arr in feature.geometry.paths[0]) {
-          console.log(feature.geometry.paths[0][arr]);
-          const convertedVals = webMercatorUtils.xyToLngLat(feature.geometry.paths[0][arr][0], feature.geometry.paths[0][arr][1])
-          console.log(convertedVals);
-          paths.push(convertedVals);
-
-        }
 
         // Remove current selection
         selectionLayer.graphics.removeAll();
 
-        // First create a line geometry (this is the Keystone pipeline)
-        var polyline = {
-          type: "polyline", // autocasts as new Polyline()
-          // paths: feature.geometry.paths[0]
-          paths: paths
-        };
-
         // Highlight the selected parcel
         highlightGraphic = new Graphic({
-          geometry: polyline,
+          geometry: feature.geometry,
           symbol: highlightLine
         });
         selectionLayer.graphics.add(highlightGraphic);

--- a/script.js
+++ b/script.js
@@ -789,13 +789,13 @@ require([
   }
 
   //Input geometry, output buffer
-  function createBuffer(response) {
+  function createBuffer(response, bufferDistance = 300, symbol = highlightSymbol) {
     var bufferGeometry = response;
-    var buffer = geometryEngine.geodesicBuffer(bufferGeometry, 300, "feet", true);
+    var buffer = geometryEngine.geodesicBuffer(bufferGeometry, bufferDistance, "feet", true);
     // add the buffer to the view as a graphic
     var bufferGraphic = new Graphic({
       geometry: buffer,
-      symbol: highlightSymbol
+      symbol: symbol
     });
     bufferLayer.graphics.removeAll();
     bufferLayer.add(bufferGraphic);
@@ -1239,6 +1239,12 @@ require([
   }
 
   function highlightFeature(feature) {
+    // this should be done at the top level of the function because
+    // anytime you try to highlight something different
+    // it should clear previous selection
+    bufferLayer.graphics.removeAll();
+    selectionLayer.graphics.removeAll();
+
     if (feature) {
       // Go to the selected parcel
       if (feature.geometry.type === "polygon") {
@@ -1246,28 +1252,10 @@ require([
         // desired condition is to not zoom, 
         // but that requirement may change in the future
       } else if (feature.geometry.type === "polyline") {
-        var ext = feature.geometry.extent;
-        var cloneExt = ext.clone();
 
-        console.log({
-          ext,
-          cloneExt,
-          featuregeometry: feature
-
-        });
-
-        // Remove current selection
-        selectionLayer.graphics.removeAll();
-
-        // Highlight the selected parcel
-        highlightGraphic = new Graphic({
-          geometry: feature.geometry,
-          symbol: highlightLine
-        });
-        selectionLayer.graphics.add(highlightGraphic);
+        createBuffer(feature.geometry, 50);
       } else if (feature.geometry.type === "point") {
         // Remove current selection
-        selectionLayer.graphics.removeAll();
 
         // Highlight the selected parcel
         highlightGraphic = new Graphic(feature.geometry, highlightPoint);
@@ -1312,8 +1300,12 @@ require([
         // Remove current selection
         selectionLayer.graphics.removeAll();
         // Highlight the selected parcel
-        highlightGraphic = new Graphic(feature.geometry, highlightSymbol);
-        selectionLayer.graphics.add(highlightGraphic);
+        // highlightGraphic = new Graphic(feature.geometry, highlightSymbol);
+        // selectionLayer.graphics.add(highlightGraphic);
+
+        createBuffer(feature.geometry);
+
+
       } else if (feature.geometry.type === "point") {
         // Remove current selection
         selectionLayer.graphics.removeAll();

--- a/script.js
+++ b/script.js
@@ -1252,15 +1252,25 @@ require([
         console.log({
           ext,
           cloneExt,
-          featuregeometry: feature.geometry
+          featuregeometry: feature
 
         });
 
         // Remove current selection
         selectionLayer.graphics.removeAll();
 
+        // First create a line geometry (this is the Keystone pipeline)
+        var polyline = {
+          type: "polyline", // autocasts as new Polyline()
+          // paths: feature.geometry.paths[0]
+          paths: feature.geometry.paths
+        };
+
         // Highlight the selected parcel
-        highlightGraphic = new Graphic(feature.geometry, highlightSymbol);
+        highlightGraphic = new Graphic({
+          geometry: polyline,
+          symbol: highlightLine
+        });
         selectionLayer.graphics.add(highlightGraphic);
       } else if (feature.geometry.type === "point") {
         // Remove current selection

--- a/script.js
+++ b/script.js
@@ -1251,14 +1251,17 @@ require([
 
         console.log({
           ext,
-          cloneExt
+          cloneExt,
+          featuregeometry: feature.geometry
+
         });
 
         // Remove current selection
         selectionLayer.graphics.removeAll();
+
         // Highlight the selected parcel
         highlightGraphic = new Graphic(feature.geometry, highlightSymbol);
-        // selectionLayer.graphics.add(highlightGraphic);
+        selectionLayer.graphics.add(highlightGraphic);
       } else if (feature.geometry.type === "point") {
         // Remove current selection
         selectionLayer.graphics.removeAll();

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ require([
   "esri/geometry/geometryEngine",
   "esri/geometry/Extent",
   "esri/geometry/Point",
+  "esri/geometry/support/webMercatorUtils",
   "esri/layers/GraphicsLayer",
   "esri/Graphic",
   "esri/tasks/IdentifyTask",
@@ -64,6 +65,7 @@ require([
   geometryEngine,
   Extent,
   Point,
+  webMercatorUtils,
   GraphicsLayer,
   Graphic,
   IdentifyTask,
@@ -316,7 +318,7 @@ require([
 
   var highlightLine = {
     type: "simple-line",
-    width: 2,
+    width: 4,
     color: [255, 0, 0, 1]
   };
 
@@ -355,7 +357,7 @@ require([
       bottom: 0
     },
     center: [-82.28, 27.8],
-    zoom: 7,
+    zoom: 8,
     constraints: {
       rotationEnabled: false
     }
@@ -1255,6 +1257,15 @@ require([
           featuregeometry: feature
 
         });
+        const paths = [];
+
+        for (arr in feature.geometry.paths[0]) {
+          console.log(feature.geometry.paths[0][arr]);
+          const convertedVals = webMercatorUtils.xyToLngLat(feature.geometry.paths[0][arr][0], feature.geometry.paths[0][arr][1])
+          console.log(convertedVals);
+          paths.push(convertedVals);
+
+        }
 
         // Remove current selection
         selectionLayer.graphics.removeAll();
@@ -1263,7 +1274,7 @@ require([
         var polyline = {
           type: "polyline", // autocasts as new Polyline()
           // paths: feature.geometry.paths[0]
-          paths: feature.geometry.paths
+          paths: paths
         };
 
         // Highlight the selected parcel

--- a/script.js
+++ b/script.js
@@ -1238,7 +1238,7 @@ require([
       });
   }
 
-  function highlightFeature(feature) {
+  function highlightFeature(feature, highlightFeature = false) {
     // this should be done at the top level of the function because
     // anytime you try to highlight something different
     // it should clear previous selection
@@ -1247,11 +1247,15 @@ require([
 
     if (feature) {
       // Go to the selected parcel
-      if (feature.geometry.type === "polygon") {
-        // do nothing
-        // desired condition is to not zoom, 
-        // but that requirement may change in the future
+      if (feature.geometry.type === "polygon" && highlightFeature === true) {
+
+        highlightGraphic = new Graphic(feature.geometry, highlightSymbol);
+        selectionLayer.graphics.add(highlightGraphic);
+
       } else if (feature.geometry.type === "polyline") {
+
+        highlightGraphic = new Graphic(feature.geometry, highlightSymbol);
+        selectionLayer.graphics.add(highlightGraphic);
 
         createBuffer(feature.geometry, 50);
       } else if (feature.geometry.type === "point") {
@@ -1273,6 +1277,31 @@ require([
         // do nothing
         // desired condition is to not zoom, 
         // but that requirement may change in the future
+        var ext = feature.geometry.extent;
+        var cloneExt = ext.clone();
+
+        console.log({
+          ext,
+          cloneExt
+        });
+
+        // if current scale is greater than number, 
+        // go to feature and expand extent by 1.75x
+        if (mapView.scale > 18055.954822) {
+          mapView.goTo({
+            target: feature,
+            extent: cloneExt.expand(1.75)
+          });
+        } else {
+          // go to point at current scale
+          mapView.goTo({
+            target: feature,
+            extent: feature.extent,
+            scale: mapView.scale
+          });
+        }
+
+
       } else if (feature.geometry.type === "polyline") {
         var ext = feature.geometry.extent;
         var cloneExt = ext.clone();
@@ -1303,7 +1332,7 @@ require([
         // highlightGraphic = new Graphic(feature.geometry, highlightSymbol);
         // selectionLayer.graphics.add(highlightGraphic);
 
-        createBuffer(feature.geometry);
+        // createBuffer(feature.geometry);
 
 
       } else if (feature.geometry.type === "point") {
@@ -2046,8 +2075,10 @@ require([
 
   // set up alert for dynamically created zoom to feature buttons
   $(document).on('click', "button[name='zoom']", function () {
-
+    console.log('click!')
     goToFeature(infoPanelData[this.id - 1]);
+    highlightFeature(infoPanelData[this.id - 1], true)
+
   });
 
   /////////////

--- a/script.js
+++ b/script.js
@@ -1114,7 +1114,7 @@ require([
       if (infoPanelData.length > 0) {
         await queryInfoPanel(event, infoPanelData, 1);
         togglePanel();
-        await goToFeature(infoPanelData[0]);
+        await highlightFeature(infoPanelData[0]);
       } else { // if no features were found under the click
         $('#infoSpan').html('Information Panel - 0 features found.');
         $('#informationdiv').append('<p>This query did not return any features</p>');
@@ -1236,6 +1236,38 @@ require([
           clearDiv('arraylengthdiv');
         }
       });
+  }
+
+  function highlightFeature(feature) {
+    if (feature) {
+      // Go to the selected parcel
+      if (feature.geometry.type === "polygon") {
+        // do nothing
+        // desired condition is to not zoom, 
+        // but that requirement may change in the future
+      } else if (feature.geometry.type === "polyline") {
+        var ext = feature.geometry.extent;
+        var cloneExt = ext.clone();
+
+        console.log({
+          ext,
+          cloneExt
+        });
+
+        // Remove current selection
+        selectionLayer.graphics.removeAll();
+        // Highlight the selected parcel
+        highlightGraphic = new Graphic(feature.geometry, highlightSymbol);
+        // selectionLayer.graphics.add(highlightGraphic);
+      } else if (feature.geometry.type === "point") {
+        // Remove current selection
+        selectionLayer.graphics.removeAll();
+
+        // Highlight the selected parcel
+        highlightGraphic = new Graphic(feature.geometry, highlightPoint);
+        selectionLayer.graphics.add(highlightGraphic);
+      }
+    }
   }
 
   // go to first feature of the infopaneldata array

--- a/script.js
+++ b/script.js
@@ -1254,9 +1254,6 @@ require([
 
       } else if (feature.geometry.type === "polyline") {
 
-        highlightGraphic = new Graphic(feature.geometry, highlightSymbol);
-        selectionLayer.graphics.add(highlightGraphic);
-
         createBuffer(feature.geometry, 50);
       } else if (feature.geometry.type === "point") {
         // Remove current selection


### PR DESCRIPTION
Created this PR to better track progress of this fix.

Currently when a user clicks on feature on the map, the response is a zoom and highlight of the feature.

The zoom and highlight were coupled together in one function. I decoupled this logic and made a highlightFeature() function to only highlight the feature.

To be completed:
This has been broken for a while, but I think this is a good opportunity to fix. The highlight of a polyline does not currently work. Trying to find a solution.

I think a solution can be found in here (https://developers.arcgis.com/javascript/latest/sample-code/sandbox/index.html?sample=view-hittest) but I think this may require a refactor of a our current code. Maybe I can find another solution that more closely resembled the current codebase.