### PR TITLE
remove zoom to feature btns when polygon

### DIFF
--- a/infopanel.js
+++ b/infopanel.js
@@ -179,15 +179,10 @@ function queryInfoPanel(results, i, event = false) {
                 );
             }
 
-            if (results[i - 1].geometry.type !== 'polygon') {
-                $('#informationdiv').append('<br>');
-                $('#informationdiv').append('<button id= "' + i + '" name="zoom" class="btn btn-primary">Zoom to Feature</button>');
-                $('#informationdiv').append('<hr>');
-            } else {
-                $('#informationdiv').append('<br>');
-                $('#informationdiv').append('<button id= "' + i + '" name="highlight" class="btn btn-primary">Highlight Feature</button>');
-                $('#informationdiv').append('<hr>');
-            }
+            $('#informationdiv').append('<br>');
+            $('#informationdiv').append('<button id= "' + i + '" name="zoom" class="btn btn-primary">Zoom to Feature</button>');
+            $('#informationdiv').append('<hr>');
+
         }
     } else {
         $('#informationdiv').append('<p>This query did not return any features</p>');

--- a/infopanel.js
+++ b/infopanel.js
@@ -185,6 +185,7 @@ function queryInfoPanel(results, i, event = false) {
                 $('#informationdiv').append('<hr>');
             } else {
                 $('#informationdiv').append('<br>');
+                $('#informationdiv').append('<button id= "' + i + '" name="highlight" class="btn btn-primary">Highlight Feature</button>');
                 $('#informationdiv').append('<hr>');
             }
         }

--- a/infopanel.js
+++ b/infopanel.js
@@ -1,4 +1,4 @@
-function queryInfoPanel(results, i, event=false) {
+function queryInfoPanel(results, i, event = false) {
 
     if (event.mapPoint) {
         $('#informationdiv').append('<a target="_blank" href=https://maps.google.com/maps?q=&layer=c&cbll=' + event.mapPoint.latitude + ',' + event.mapPoint.longitude + '>Google Street View&nbsp</a> <span class="esri-icon-description" data-toggle="tooltip" data-placement="top" title="Please note: if not clicked where there are streets, no imagery will be returned."></span><br><br>');
@@ -19,6 +19,11 @@ function queryInfoPanel(results, i, event=false) {
                     '<b>FIPS:</b> ' + results[i - 1].attributes.cfips + '<br>' +
                     '<b>Area:</b> ' + results[i - 1].attributes.st_area + '<br>' +
                     '<b>Layer Name:</b> ' + results[i - 1].attributes.layerName + '<br>'
+                );
+            } else if (results[i - 1].attributes.layerName === 'County_Boundaries_Shoreline') {
+                $('#informationdiv').append('<p style= "font-size: 15px"><b>County Boundary</b></p>' +
+                    '<b>County Name:</b> ' + results[i - 1].attributes.tigername + '<br>' +
+                    '<b>FIPS:</b> ' + results[i - 1].attributes.fips + '<br>'
                 );
             } else if (results[i - 1].attributes.layerName === 'Soils June 2012 - Dept. of Agriculture') {
                 $('#informationdiv').append('<p style= "font-size: 15px"><b>Soils June 2012 - Dept. of Agriculture</b></p>' +
@@ -45,8 +50,8 @@ function queryInfoPanel(results, i, event=false) {
                     '<a target="_blank" href=' + 'https://labins.org/mapping_data/aerials/hi-res_search_from_map.cfm?spzone=N&gridid=' + results[i - 1].attributes.spn_id + '>' + 'Hi resolution images for ' + results[i - 1].attributes.spn_id + '</a><br>'
                 );
             } else if (results[i - 1].attributes.layerName === 'NGS Control Points') {
-            	$('#informationdiv').append('<p style= "font-size: 15px"><b>NGS Control Points</b></p>' +
-                	'Control Point Name: ' + results[i - 1].attributes.name + '<br>' +
+                $('#informationdiv').append('<p style= "font-size: 15px"><b>NGS Control Points</b></p>' +
+                    'Control Point Name: ' + results[i - 1].attributes.name + '<br>' +
                     'Latitude, Longitude: ' + results[i - 1].attributes.dec_lat + ', ' + results[i - 1].attributes.dec_long + '<br>' +
                     'County: ' + results[i - 1].attributes.county + '<br>' +
                     'PID: ' + results[i - 1].attributes.pid + '<br>' +
@@ -164,7 +169,7 @@ function queryInfoPanel(results, i, event=false) {
                 });
                 // add .tif files to popup
                 tifFiles.map(fileName => {
-                    $('#informationdiv').append('<b>Image: </b><a target="_blank" href=' + fileName + '>' + fileName.slice(-12,-4) + '.tif</a><br>');
+                    $('#informationdiv').append('<b>Image: </b><a target="_blank" href=' + fileName + '>' + fileName.slice(-12, -4) + '.tif</a><br>');
                 });
             } else if (results[i - 1].attributes.layerName === 'Coastal Construction Control Lines') {
                 $('#informationdiv').append('<p style= "font-size: 15px"><b>Coastal Construction Control Lines</b></p>' +
@@ -173,9 +178,15 @@ function queryInfoPanel(results, i, event=false) {
                     '<b>MHW: </b>' + results[i - 1].attributes.OBJECTID + '<br>'
                 );
             }
-            $('#informationdiv').append('<br>');
-            $('#informationdiv').append('<button id= "' + i + '" name="zoom" class="btn btn-primary">Zoom to Feature</button>');
-            $('#informationdiv').append('<hr>');
+
+            if (results[i - 1].geometry.type !== 'polygon') {
+                $('#informationdiv').append('<br>');
+                $('#informationdiv').append('<button id= "' + i + '" name="zoom" class="btn btn-primary">Zoom to Feature</button>');
+                $('#informationdiv').append('<hr>');
+            } else {
+                $('#informationdiv').append('<br>');
+                $('#informationdiv').append('<hr>');
+            }
         }
     } else {
         $('#informationdiv').append('<p>This query did not return any features</p>');

--- a/script.js
+++ b/script.js
@@ -1984,6 +1984,16 @@ require([
     goToFeature(infoPanelData[this.id - 1]);
   });
 
+  // set up alert for dynamically created zoom to feature buttons
+  $(document).on('click', "button[name='highlight']", function () {
+    mapView.graphics.removeAll();
+    selectionLayer.graphics.removeAll();
+    graphicArray = [];
+    highlightGraphic = new Graphic(infoPanelData[this.id - 1].geometry, highlightSymbol);
+    graphicArray.push(highlightGraphic);
+    selectionLayer.graphics.addMany(graphicArray);
+  });
+
   /////////////
   // Widgets //
   /////////////

--- a/script.js
+++ b/script.js
@@ -1984,16 +1984,6 @@ require([
     goToFeature(infoPanelData[this.id - 1]);
   });
 
-  // set up alert for dynamically created zoom to feature buttons
-  $(document).on('click', "button[name='highlight']", function () {
-    mapView.graphics.removeAll();
-    selectionLayer.graphics.removeAll();
-    graphicArray = [];
-    highlightGraphic = new Graphic(infoPanelData[this.id - 1].geometry, highlightSymbol);
-    graphicArray.push(highlightGraphic);
-    selectionLayer.graphics.addMany(graphicArray);
-  });
-
   /////////////
   // Widgets //
   /////////////

--- a/script.js
+++ b/script.js
@@ -1233,11 +1233,11 @@ require([
 
     if (feature) {
       // Go to the selected parcel
-      if (feature.geometry.type === "polygon") {
-        // do nothing
-        // desired condition is to not zoom, 
-        // but that requirement may change in the future
-      } else if (feature.geometry.type === "polyline") {
+      // if (feature.geometry.type === "polygon") {
+      // do nothing
+      // desired condition is to not zoom, 
+      // but that requirement may change in the future
+      if (feature.geometry.type === "polyline" || feature.geometry.type === "polygon") {
         var ext = feature.geometry.extent;
         var cloneExt = ext.clone();
         // if current scale is greater than number, 


### PR DESCRIPTION
I think it's a bit misleading to the user to have a zoom to feature btn available on a polygon element in the information panel. We don't have logic in the code to zoom to this anymore. 


Is this a better reflection of the behavior we want? 

In essense, the user now does not get the option to "Zoom to Feature" for polygons, but that functionality exists for other geometry types. 

I think we lose some of the interactive functionality of the map this way though. To expand on that, should we instead perform a highlight instead of a zoom? 

![image](https://user-images.githubusercontent.com/24685932/81588606-c815e400-9386-11ea-916d-ae7e94e3943c.png)
