### PR TITLE
#131 this will correct the dropdown resetting

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
           </li>
           <select id="selectTownship" class="form-control trs"></select>
           <select id="selectRange" class="form-control trs"></select>
-          <select id="selectSection" class="form-control trs"></select>
+          <select id="selectSection" class="form-control"></select>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -147,9 +147,15 @@
           <li class="dropdown-header" style="color: #DCDCDC">
             <font size="3">Zoom to Township/Range/Section</font>
           </li>
-          <select id="selectTownship" class="form-control trs"></select>
-          <select id="selectRange" class="form-control trs"></select>
-          <select id="selectSection" class="form-control trs"></select>
+          <select id="selectTownship" class="form-control trs">
+            <option value="" disabled selected>Township</option>
+          </select>
+          <select id="selectRange" class="form-control trs">
+            <option value="" disabled selected>Range</option>
+          </select>
+          <select id="selectSection" class="form-control trs">
+            <option value="" disabled selected>Section</option>
+          </select>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -147,9 +147,9 @@
           <li class="dropdown-header" style="color: #DCDCDC">
             <font size="3">Zoom to Township/Range/Section</font>
           </li>
-          <select id="selectTownship" class="form-control"></select>
-          <select id="selectRange" class="form-control"></select>
-          <select id="selectSection" class="form-control"></select>
+          <select id="selectTownship" class="form-control trs"></select>
+          <select id="selectRange" class="form-control trs"></select>
+          <select id="selectSection" class="form-control trs"></select>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
           <select id="selectCityPanel" class="form-control"></select>
           <select id="selectQuadPanel" class="form-control"></select>
         </div>
-        <div class="panel-body">
+        <div class="panel-body" id="trs">
           <li class="dropdown-header" style="color: #DCDCDC">
             <font size="3">Zoom to Township/Range/Section</font>
           </li>

--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
           </li>
           <select id="selectTownship" class="form-control trs"></select>
           <select id="selectRange" class="form-control trs"></select>
-          <select id="selectSection" class="form-control"></select>
+          <select id="selectSection" class="form-control trs"></select>
         </div>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -949,6 +949,11 @@ require([
   // Add the unique values to the
   // section selection element.
   function buildSectionDropdown(values) {
+    // remove sections
+    for (j = sectionSelect.options.length - 1; j >= 0; j--) {
+      sectionSelect.remove(j);
+    }
+
     const option = domConstruct.create("option");
     option.text = "Zoom to a Section";
     sectionSelect.add(option);

--- a/script.js
+++ b/script.js
@@ -946,10 +946,7 @@ require([
   // Add the unique values to the
   // section selection element.
   function buildSectionDropdown(values) {
-    // remove sections
-    for (j = sectionSelect.options.length - 1; j >= 0; j--) {
-      sectionSelect.remove(j);
-    }
+    document.getElementById(id).options.length = 0;
 
     const option = domConstruct.create("option");
     option.text = "Zoom to a Section";

--- a/script.js
+++ b/script.js
@@ -949,6 +949,8 @@ require([
   // Add the unique values to the
   // section selection element.
   function buildSectionDropdown(values) {
+    console.log({values});
+    
     // remove sections
     for (j = sectionSelect.options.length - 1; j >= 0; j--) {
       sectionSelect.remove(j);
@@ -962,6 +964,12 @@ require([
     const disctinctSectionsArr = [...new Set(sectionIntArr)];
     const sortedSections = disctinctSectionsArr.sort((a, b) => a-b).map(element => element.toString().padStart(2, '0'));
 
+    console.log({
+      sectionArr,
+      sectionIntArr,
+      disctinctSectionsArr,
+      sortedSections
+    })
     sortedSections.forEach(function (value) {
       const option = domConstruct.create("option");
       option.text = value
@@ -1009,7 +1017,8 @@ require([
       const townshipValue = townshipSelect.value;
       const TRQuery = new Query({
         where: "rng_ch = '" + type.substr(0, 2) + "' AND rdir = '" + type.substr(2) + "' AND twn_ch = '" + townshipValue.substr(0, 2) + "' AND tdir = '" + townshipValue.substr(2) + "'",
-        returnGeometry: true
+        returnGeometry: true,
+        outFields: ["*"]
       });
       townshipRangeSectionLayer.queryFeatures(TRQuery)
       .then(results => handleResults(results))

--- a/script.js
+++ b/script.js
@@ -980,6 +980,9 @@ require([
     for (i = rangeSelect.options.length - 1; i >= 0; i--) {
       rangeSelect.remove(i);
     }
+    for (j = sectionSelect.options.length - 1; j >= 0; j--) {
+      sectionSelect.remove(j);
+    }
 
     var rangeQuery = new Query({
       where: "twn_ch = '" + type.substr(0, 2) + "' AND tdir = '" + type.substr(2) + "'",

--- a/script.js
+++ b/script.js
@@ -990,8 +990,7 @@ require([
   }
 
   async function queryTR (type, whichDropdown) {
-    if(whichDropdown === 'range') { 
-      if (townshipSelect.value !== "Zoom to a Township") { // check to see if combo is valid if populated
+    if(whichDropdown === 'selectRange' && townshipSelect.selectedIndex !== 0) {
         const townshipValue = townshipSelect.value;
         const TRQuery = new Query({
           where: "rng_ch = '" + type.substr(0, 2) + "' AND rdir = '" + type.substr(2) + "' AND twn_ch = '" + townshipValue.substr(0, 2) + "' AND tdir = '" + townshipValue.substr(2) + "'",

--- a/script.js
+++ b/script.js
@@ -882,9 +882,9 @@ require([
   //// Zoom to Township/Section/Range Feature ////
   ////////////////////////////////////////////////
 
-  const townshipSelect = dom.byId("selectTownship");
-  const rangeSelect = dom.byId("selectRange");
-  const sectionSelect = dom.byId("selectSection");
+  const townshipSelect = document.getElementById("selectTownship");
+  const rangeSelect = document.getElementById("selectRange");
+  const sectionSelect = document.getElementById("selectSection");
 
   // when mapView is ready, build the first dropdown for township selection
   mapView.when(async function () {

--- a/script.js
+++ b/script.js
@@ -699,38 +699,6 @@ require([
     }
   }
 
-  // reset dropdowns and all inputs that are not equal to the current element. 
-  // function resetElements(currentElement, trs = false) {
-  //   // if elements are not equal to the current element
-  //   // then reset to the initial values
-  //   // find all dropdowns
-    
-  //   $("select").each(function () {
-  //     if (trs) {
-  //       if (
-  //         (this != currentElement) && 
-  //         (this != document.getElementById('selectLayerDropdown')) && 
-  //         (this != document.getElementById('selectTownship')) && 
-  //         (this != document.getElementById('selectRange')) && 
-  //         (this != document.getElementById('selectSection'))
-  //       ) {
-  //           this.selectedIndex = 0
-  //         }
-  //       } else {
-  //         if ((this != currentElement) && (this != document.getElementById('selectLayerDropdown'))) {
-  //           this.selectedIndex = 0
-  //         }
-  //       }
-  //     },
-  //     // find all inputs
-  //     $("input").each(function () {
-  //       if (this != currentElement) {
-  //         $(this).val('');
-  //       }
-  //     })
-  //   );
-  // }
-
   function resetElements(currentElement, trs = false) {
     console.log(trs);
     let doNotSelect = "#" + currentElement.id + ", #selectLayerDropdown";

--- a/script.js
+++ b/script.js
@@ -1000,8 +1000,7 @@ require([
         queryTRFlow(TRQuery);
         //place the tr function here
       }
-    } else if (whichDropdown === 'township') {
-        if (rangeSelect.value !== "Zoom to a Range") { // check to see if combo is valid if populated
+    } else if (whichDropdown === 'selectTownship' && rangeSelect.selectedIndex !== 0) {
           const rangeValue = rangeSelect.value;
           const TRQuery = new Query({
             where: "twn_ch = '" + type.substr(0, 2) + "' AND tdir = '" + type.substr(2) + "' AND rng_ch = '" + rangeValue.substr(0, 2) + "' AND rdir = '" + rangeValue.substr(2) + "'",

--- a/script.js
+++ b/script.js
@@ -700,13 +700,19 @@ require([
   }
 
   // reset dropdowns and all inputs that are not equal to the current element. 
-  function resetElements(currentElement) {
+  function resetElements(currentElement, trs = false) {
     // if elements are not equal to the current element
     // then reset to the initial values
     // find all dropdowns
     $("select").each(function () {
-        if ((this != currentElement) && (this != document.getElementById('selectLayerDropdown'))) {
-          this.selectedIndex = 0
+      if (trs) {
+        if ((this != currentElement) && (this != document.getElementById('selectLayerDropdown')) && (this != document.getElementById('selectTownship')) && (this != document.getElementById('selectRange')) && (this != document.getElementById('selectSection'))) {
+            this.selectedIndex = 0
+          }
+        } else {
+          if ((this != currentElement) && (this != document.getElementById('selectLayerDropdown'))) {
+            this.selectedIndex = 0
+          }
         }
       },
       // find all inputs
@@ -771,6 +777,7 @@ require([
     });
     const response = await task.execute(params)
     mapView.goTo(response.features);
+    bufferLayer.graphics.removeAll();
     selectionLayer.graphics.removeAll();
     graphicArray = [];
     for (feature of response.features) {
@@ -979,6 +986,7 @@ require([
 
   // when township changes, reset the other dropdowns.
   on(townshipSelect, "change", function (evt) {
+    resetElements(townshipSelect, true);
     var type = evt.target.value;
     var i;
     for (i = rangeSelect.options.length - 1; i >= 0; i--) {
@@ -996,6 +1004,7 @@ require([
 
   // when range changes, reset the section dropdown.
   on(rangeSelect, "change", function (evt) {
+    resetElements(rangeSelect, true);
     var type = evt.target.value;
     var j;
     for (j = sectionSelect.options.length - 1; j >= 0; j--) {
@@ -1016,6 +1025,7 @@ require([
 
   var querySection = dom.byId("selectSection");
   on(querySection, "change", function (e) {
+    resetElements(sectionSelect, true);
     var type = e.target.value;
     zoomToSectionFeature(townshipRangeSectionURL, type, "sec_ch");
   });

--- a/script.js
+++ b/script.js
@@ -990,7 +990,7 @@ require([
   }
 
   async function queryTR (type, whichDropdown) {
-    if(whichDropdown === 'selectRange' && townshipSelect.selectedIndex !== 0) {
+    if (whichDropdown === 'selectRange' && townshipSelect.selectedIndex !== 0) {
         const townshipValue = townshipSelect.value;
         const TRQuery = new Query({
           where: "rng_ch = '" + type.substr(0, 2) + "' AND rdir = '" + type.substr(2) + "' AND twn_ch = '" + townshipValue.substr(0, 2) + "' AND tdir = '" + townshipValue.substr(2) + "'",
@@ -999,7 +999,6 @@ require([
         });
         queryTRFlow(TRQuery);
         //place the tr function here
-      }
     } else if (whichDropdown === 'selectTownship' && rangeSelect.selectedIndex !== 0) {
           const rangeValue = rangeSelect.value;
           const TRQuery = new Query({
@@ -1008,22 +1007,21 @@ require([
             returnGeometry: true
           });
           queryTRFlow(TRQuery);
-        }
       }
-    }
-
+    } 
+    
   // when township changes, reset the section dropdown and execute queryTR.
   on(townshipSelect, "change", function (evt) {
     resetElements(townshipSelect, false);
     const type = evt.target.value;
-    queryTR(type, 'township');
+    queryTR(type, 'selectTownship');
   });
 
   // when range changes, reset the section dropdown and execute queryTR .
   on(rangeSelect, "change", function (evt) {
     resetElements(rangeSelect, false);
     const type = evt.target.value;
-    queryTR(type, 'range');
+    queryTR(type, 'selectRange');
   });
 
   on(sectionSelect, "change", function (e) {

--- a/script.js
+++ b/script.js
@@ -907,21 +907,30 @@ require([
   //// Zoom to Township/Section/Range Feature ////
   ////////////////////////////////////////////////
 
-  var townshipSelect = dom.byId("selectTownship");
-  var rangeSelect = dom.byId("selectRange");
-  var sectionSelect = dom.byId("selectSection");
+  const townshipSelect = dom.byId("selectTownship");
+  const rangeSelect = dom.byId("selectRange");
+  const sectionSelect = dom.byId("selectSection");
 
   // when mapView is ready, build the first dropdown for township selection
   mapView.when(async function () {
-    var townshipQuery = new Query({
+    const townshipQuery = new Query({
       where: "tdir <> ' ' AND NOT (CAST(twn_ch AS int) > '8' AND tdir = 'N')",
       outFields: ["twn_ch", "tdir"],
       returnDistinctValues: true,
-      orderByFields: ["twn_ch", "tdir"],
+      orderByFields: ["twn_ch", "tdir"]
     });
+
+    const rangeQuery = new Query({
+      where: "rdir <> ' '",
+      outFields: ["rng_ch", "rdir"],
+      returnDistinctValues: true,
+      orderByFields: ["rng_ch", "rdir"]
+    })
     try {
-      const results = await townshipRangeSectionLayer.queryFeatures(townshipQuery);
-      await buildTownshipDropdown(results);
+      const townshipResults = await townshipRangeSectionLayer.queryFeatures(townshipQuery);
+      const rangeResults = await townshipRangeSectionLayer.queryFeatures(rangeQuery);
+      await buildTownshipDropdown(townshipResults);
+      await buildRangeDropdown(rangeResults);
     } catch (err) {
       console.log('Township load failed: ', err);
     }

--- a/script.js
+++ b/script.js
@@ -700,35 +700,49 @@ require([
   }
 
   // reset dropdowns and all inputs that are not equal to the current element. 
+  // function resetElements(currentElement, trs = false) {
+  //   // if elements are not equal to the current element
+  //   // then reset to the initial values
+  //   // find all dropdowns
+    
+  //   $("select").each(function () {
+  //     if (trs) {
+  //       if (
+  //         (this != currentElement) && 
+  //         (this != document.getElementById('selectLayerDropdown')) && 
+  //         (this != document.getElementById('selectTownship')) && 
+  //         (this != document.getElementById('selectRange')) && 
+  //         (this != document.getElementById('selectSection'))
+  //       ) {
+  //           this.selectedIndex = 0
+  //         }
+  //       } else {
+  //         if ((this != currentElement) && (this != document.getElementById('selectLayerDropdown'))) {
+  //           this.selectedIndex = 0
+  //         }
+  //       }
+  //     },
+  //     // find all inputs
+  //     $("input").each(function () {
+  //       if (this != currentElement) {
+  //         $(this).val('');
+  //       }
+  //     })
+  //   );
+  // }
+
   function resetElements(currentElement, trs = false) {
-    // if elements are not equal to the current element
-    // then reset to the initial values
-    // find all dropdowns
-    $("select").each(function () {
-      if (trs) {
-        if (
-          (this != currentElement) && 
-          (this != document.getElementById('selectLayerDropdown')) && 
-          (this != document.getElementById('selectTownship')) && 
-          (this != document.getElementById('selectRange')) && 
-          (this != document.getElementById('selectSection'))
-        ) {
-            this.selectedIndex = 0
-          }
-        } else {
-          if ((this != currentElement) && (this != document.getElementById('selectLayerDropdown'))) {
-            this.selectedIndex = 0
-          }
-        }
-      },
-      // find all inputs
-      $("input").each(function () {
-        if (this != currentElement) {
-          $(this).val('');
-        }
-      })
-    );
-  }
+    console.log(trs);
+    let doNotSelect = "#" + currentElement.id + ", #selectLayerDropdown";
+    doNotSelect = trs ? doNotSelect + ", .trs" : doNotSelect;
+    console.log(doNotSelect);
+    
+    $("select").not(doNotSelect).each(function () {
+      console.log(this);
+      this.selectedIndex = 0;
+    });
+  }   
+
 
   /////////////////////////////
   /// Dropdown Select Panel ///

--- a/script.js
+++ b/script.js
@@ -980,7 +980,11 @@ require([
           $("#TRSAlert").fadeTo(500, 0).slideUp(500, function(){
               $(this).remove(); 
           });
-      }, 4000);
+        }, 4000);
+        // remove sections
+        for (j = sectionSelect.options.length - 1; j >= 0; j--) {
+          sectionSelect.remove(j);
+        }
         throw new Error('This is an invalid Township-Range combination');;
     }
   }

--- a/script.js
+++ b/script.js
@@ -952,9 +952,8 @@ require([
     option.text = "Zoom to a Section";
     sectionSelect.add(option);
     const sectionArr = values.features
-    const sectionIntArr = sectionArr.map(element => parseInt(element.attributes.sec_ch));
-    const disctinctSectionsArr = [...new Set(sectionIntArr)];
-    const sortedSections = disctinctSectionsArr.sort((a, b) => a-b).map(element => element.toString().padStart(2, '0'));
+    const sectionIntArr = sectionArr.map(element => element.attributes.sec_ch);
+    const sortedSections = [...new Set(sectionIntArr)].sort();
 
     sortedSections.forEach(function (value) {
       const option = domConstruct.create("option");

--- a/script.js
+++ b/script.js
@@ -962,7 +962,7 @@ require([
     });
   }
 
-  const handleNoResults = results => {
+  const validateResults = results => {
         $("#trs").prepend(
           `<div id="TRSAlert" class="alert alert-danger" role="alert">
             <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
@@ -985,7 +985,7 @@ require([
       zoomToTRFeature(results)
       buildSectionDropdown(results)
     } else {
-      handleNoResults(results);
+      validateResults(results);
     }
   }
 
@@ -1009,7 +1009,7 @@ require([
           queryTRFlow(TRQuery);
       }
     } 
-    
+
   // when township changes, reset the section dropdown and execute queryTR.
   on(townshipSelect, "change", function (evt) {
     resetElements(townshipSelect, false);

--- a/script.js
+++ b/script.js
@@ -946,7 +946,7 @@ require([
   // Add the unique values to the
   // section selection element.
   function buildSectionDropdown(values) {
-    document.getElementById(id).options.length = 0;
+    sectionSelect.options.length = 0;
 
     const option = domConstruct.create("option");
     option.text = "Zoom to a Section";

--- a/script.js
+++ b/script.js
@@ -821,45 +821,16 @@ require([
   }
 
   function zoomToTRFeature1(results) {
-    console.log(results);
-    
-    multiPolygonGeometries = [];
-
+    console.log(results.features);
     mapView.goTo(results.features);
-    return;
-    // selectionLayer.graphics.removeAll();
-    // bufferLayer.graphics.removeAll();
-    // graphicArray = [];
-    // for (i = 0; i < results.features.length; i++) {
-    //   highlightGraphic = new Graphic(results.features[i].geometry, highlightSymbol);
-    //   graphicArray.push(highlightGraphic);
-    //   multiPolygonGeometries.push(results.features[i].geometry);
-    // }
-    // selectionLayer.graphics.addMany(graphicArray);
-    // return results;
-
-    // var task = new QueryTask({
-    //   url: panelurl
-    // });
-    // var params = new Query({
-    //   where: "twn_ch = '" + strUser.substr(0, 2) + "' AND tdir = '" + strUser.substr(2) + "' AND rng_ch = '" + rangeUser.substr(0, 2) + "' AND rdir = '" + rangeUser.substr(2) + "'",
-    //   returnGeometry: true
-    // });
-    // task.execute(params)
-    //   .then(function (response) {
-    //     mapView.goTo(response.features);
-    //     selectionLayer.graphics.removeAll();
-    //     bufferLayer.graphics.removeAll();
-    //     graphicArray = [];
-    //     for (i = 0; i < response.features.length; i++) {
-    //       highlightGraphic = new Graphic(response.features[i].geometry, highlightSymbol);
-    //       graphicArray.push(highlightGraphic);
-    //       multiPolygonGeometries.push(response.features[i].geometry);
-    //     }
-    //     selectionLayer.graphics.addMany(graphicArray);
-    //     return response;
-    //   })
-    //   .then(unionGeometries);
+    bufferLayer.graphics.removeAll();
+    selectionLayer.graphics.removeAll();
+    graphicArray = [];
+    for (feature of results.features) {
+      highlightGraphic = new Graphic(feature.geometry, highlightSymbol);
+      graphicArray.push(highlightGraphic);
+    }
+    selectionLayer.graphics.addMany(graphicArray);
   }
 
   // Modified zoomToFeature function to zoom once the Township and Range has been chosen
@@ -883,19 +854,22 @@ require([
     });
     task.execute(params)
       .then(function (response) {
-        mapView.goTo(response.features);
-        selectionLayer.graphics.removeAll();
-        bufferLayer.graphics.removeAll();
-        graphicArray = [];
-        for (i = 0; i < response.features.length; i++) {
-          highlightGraphic = new Graphic(response.features[i].geometry, highlightSymbol);
-          graphicArray.push(highlightGraphic);
-          multiPolygonGeometries.push(response.features[i].geometry);
-        }
-        selectionLayer.graphics.addMany(graphicArray);
-        return response;
-      })
-      .then(unionGeometries);
+        console.log(response);
+        // zoomToTRFeature1(response)
+        // mapView.goTo(response.features);
+      });
+      //   selectionLayer.graphics.removeAll();
+      //   bufferLayer.graphics.removeAll();
+      //   graphicArray = [];
+      //   for (i = 0; i < response.features.length; i++) {
+      //     highlightGraphic = new Graphic(response.features[i].geometry, highlightSymbol);
+      //     graphicArray.push(highlightGraphic);
+      //     multiPolygonGeometries.push(response.features[i].geometry);
+      //   }
+      //   selectionLayer.graphics.addMany(graphicArray);
+      //   return response;
+      // })
+      // .then(unionGeometries);
   }
 
   //Input geometry, output buffer
@@ -1055,7 +1029,7 @@ require([
                   reject(reason); // reject
                   throw reason;
               }
-      
+      f
           });
       }
     
@@ -1063,7 +1037,8 @@ require([
       const rangeValue = rangeSelect.value;
       const TRQuery = new Query({
         where: "twn_ch = '" + type.substr(0, 2) + "' AND tdir = '" + type.substr(2) + "' AND rng_ch = '" + rangeValue.substr(0, 2) + "' AND rdir = '" + rangeValue.substr(2) + "'",
-        returnDistinctValues: true,
+        // returnDistinctValues: true,
+        returnGeometry: true
       });
       townshipRangeSectionLayer.queryFeatures(TRQuery)
       // .then(results => handleResults(results))

--- a/script.js
+++ b/script.js
@@ -826,16 +826,17 @@ require([
     multiPolygonGeometries = [];
 
     mapView.goTo(results.features);
-    selectionLayer.graphics.removeAll();
-    bufferLayer.graphics.removeAll();
-    graphicArray = [];
-    for (i = 0; i < response.features.length; i++) {
-      highlightGraphic = new Graphic(response.features[i].geometry, highlightSymbol);
-      graphicArray.push(highlightGraphic);
-      multiPolygonGeometries.push(response.features[i].geometry);
-    }
-    selectionLayer.graphics.addMany(graphicArray);
-    return response;
+    return;
+    // selectionLayer.graphics.removeAll();
+    // bufferLayer.graphics.removeAll();
+    // graphicArray = [];
+    // for (i = 0; i < results.features.length; i++) {
+    //   highlightGraphic = new Graphic(results.features[i].geometry, highlightSymbol);
+    //   graphicArray.push(highlightGraphic);
+    //   multiPolygonGeometries.push(results.features[i].geometry);
+    // }
+    // selectionLayer.graphics.addMany(graphicArray);
+    // return results;
 
     // var task = new QueryTask({
     //   url: panelurl
@@ -1023,11 +1024,6 @@ require([
     });
   }
 
-  function buildTownshipRangeDropdown (townshipSelect, rangeSelect) {
-
-
-  }
-
   // when township changes, reset the other dropdowns.
   on(townshipSelect, "change", function (evt) {
     resetElements(townshipSelect, false);
@@ -1070,12 +1066,12 @@ require([
         returnDistinctValues: true,
       });
       townshipRangeSectionLayer.queryFeatures(TRQuery)
-      .then(results => handleResults(results))
+      // .then(results => handleResults(results))
       .then(results => {
-        console.log(results);
+        console.log({results});
         zoomToTRFeature1(results)
       })
-      .then(results => unionGeometries(results))
+      // .then(results => unionGeometries(results))
       .catch((error) => {
         console.error(error);
       });

--- a/script.js
+++ b/script.js
@@ -699,10 +699,10 @@ require([
     }
   }
 
-  function resetElements(currentElement, trs = false) {
+  function resetElements(currentElement, trs = true) {
     console.log(trs);
     let doNotSelect = "#" + currentElement.id + ", #selectLayerDropdown";
-    doNotSelect = trs ? doNotSelect + ", .trs" : doNotSelect;
+    doNotSelect = trs ? doNotSelect : doNotSelect + ", .trs" ;
     console.log(doNotSelect);
     
     $("select").not(doNotSelect).each(function () {
@@ -974,7 +974,7 @@ require([
 
   // when township changes, reset the other dropdowns.
   on(townshipSelect, "change", function (evt) {
-    resetElements(townshipSelect, true);
+    resetElements(townshipSelect, false);
     var type = evt.target.value;
     var i;
     for (i = rangeSelect.options.length - 1; i >= 0; i--) {
@@ -992,7 +992,7 @@ require([
 
   // when range changes, reset the section dropdown.
   on(rangeSelect, "change", function (evt) {
-    resetElements(rangeSelect, true);
+    resetElements(rangeSelect, false);
     var type = evt.target.value;
     var j;
     for (j = sectionSelect.options.length - 1; j >= 0; j--) {
@@ -1013,7 +1013,7 @@ require([
 
   var querySection = dom.byId("selectSection");
   on(querySection, "change", function (e) {
-    resetElements(sectionSelect, true);
+    resetElements(sectionSelect, false);
     var type = e.target.value;
     zoomToSectionFeature(townshipRangeSectionURL, type, "sec_ch");
   });

--- a/script.js
+++ b/script.js
@@ -820,7 +820,7 @@ require([
       .then(createBuffer)
   }
 
-  function zoomToTRFeature1(results) {
+  function zoomToTRFeature(results) {
     console.log(results.features);
     mapView.goTo(results.features);
     bufferLayer.graphics.removeAll();
@@ -831,45 +831,6 @@ require([
       graphicArray.push(highlightGraphic);
     }
     selectionLayer.graphics.addMany(graphicArray);
-  }
-
-  // Modified zoomToFeature function to zoom once the Township and Range has been chosen
-  function zoomToTRFeature(panelurl, location, attribute) {
-    
-
-    multiPolygonGeometries = [];
-
-    var township = document.getElementById("selectTownship");
-    var strUser = township.options[township.selectedIndex].text;
-
-    var range = document.getElementById("selectRange");
-    var rangeUser = range.options[range.selectedIndex].text;
-
-    var task = new QueryTask({
-      url: panelurl
-    });
-    var params = new Query({
-      where: "twn_ch = '" + strUser.substr(0, 2) + "' AND tdir = '" + strUser.substr(2) + "' AND rng_ch = '" + rangeUser.substr(0, 2) + "' AND rdir = '" + rangeUser.substr(2) + "'",
-      returnGeometry: true
-    });
-    task.execute(params)
-      .then(function (response) {
-        console.log(response);
-        // zoomToTRFeature1(response)
-        // mapView.goTo(response.features);
-      });
-      //   selectionLayer.graphics.removeAll();
-      //   bufferLayer.graphics.removeAll();
-      //   graphicArray = [];
-      //   for (i = 0; i < response.features.length; i++) {
-      //     highlightGraphic = new Graphic(response.features[i].geometry, highlightSymbol);
-      //     graphicArray.push(highlightGraphic);
-      //     multiPolygonGeometries.push(response.features[i].geometry);
-      //   }
-      //   selectionLayer.graphics.addMany(graphicArray);
-      //   return response;
-      // })
-      // .then(unionGeometries);
   }
 
   //Input geometry, output buffer
@@ -998,40 +959,40 @@ require([
     });
   }
 
+  // function handleResults(results) {
+  //   new Promise(
+  //     function (resolve, reject) {
+  //         if (results) {
+  //           console.log(results);
+            
+  //           return Promise.resolve(results); // fulfilled
+  //           return results;
+  //         } else {
+  //             var reason = new Error('This is an invalid Township-Range combination');
+  //             reject(reason); // reject
+  //             throw reason;
+  //         }
+  //     });
+  // }
+
+  const handleResults = results => {
+    if (results.features.length > 0) {
+      console.log(results);
+      
+      return results;
+    } else {
+        console.log('reject!');
+        
+        var reason = new Error('This is an invalid Township-Range combination');
+        throw reason;
+    }
+  }
+
   // when township changes, reset the other dropdowns.
   on(townshipSelect, "change", function (evt) {
     resetElements(townshipSelect, false);
     var type = evt.target.value;
     var i;
-    // for (i = rangeSelect.options.length - 1; i >= 0; i--) {
-    //   rangeSelect.remove(i);
-    // }
-    // for (j = sectionSelect.options.length - 1; j >= 0; j--) {
-    //   sectionSelect.remove(j);
-    // }
-
-    // var rangeQuery = new Query({
-    //   where: "twn_ch = '" + type.substr(0, 2) + "' AND tdir = '" + type.substr(2) + "'",
-    //   outFields: ["rng_ch", "rdir"],
-    //   returnDistinctValues: true,
-    //   orderByFields: ["rng_ch", "rdir"]
-    // });
-      function handleResults(results) {
-        new Promise(
-          function (resolve, reject) {
-              if (results) {
-                console.log(results);
-                
-                // resolve(results); // fulfilled
-                return resolve(results);
-              } else {
-                  var reason = new Error('This is an invalid Township-Range combination');
-                  reject(reason); // reject
-                  throw reason;
-              }
-      f
-          });
-      }
     
     if (rangeSelect.value !== "Zoom to a Range") { // check to see if combo is valid
       const rangeValue = rangeSelect.value;
@@ -1041,16 +1002,16 @@ require([
         returnGeometry: true
       });
       townshipRangeSectionLayer.queryFeatures(TRQuery)
-      // .then(results => handleResults(results))
+      .then(results => handleResults(results))
       .then(results => {
         console.log({results});
-        zoomToTRFeature1(results)
+        zoomToTRFeature(results)
       })
       // .then(results => unionGeometries(results))
       .catch((error) => {
         console.error(error);
       });
-      // .then(zoomToTRFeature(townshipRangeSectionURL, type, "rng_ch")
+      // .then(zoomToTRFeature(results)
       // .then(handleResults(results)))
     }
     // return townshipRangeSectionLayer.queryFeatures(rangeQuery).then(buildRangeDropdown);

--- a/script.js
+++ b/script.js
@@ -949,37 +949,26 @@ require([
   // Add the unique values to the
   // section selection element.
   function buildSectionDropdown(values) {
-    console.log({values});
-    
-    var option = domConstruct.create("option");
+    const option = domConstruct.create("option");
     option.text = "Zoom to a Section";
     sectionSelect.add(option);
+    const sectionArr = values.features
+    const sectionIntArr = sectionArr.map(element => parseInt(element.attributes.sec_ch));
+    const disctinctSectionsArr = [...new Set(sectionIntArr)];
+    const sortedSections = disctinctSectionsArr.sort((a, b) => a-b).map(element => element.toString().padStart(2, '0'));
 
-    sections = values.features
-
-    sections = sections.map(element => parseInt(element.attributes.sec_ch));
-    
-    console.log(sections);
-    sections = sections.sort((a, b) => a-b);
-    console.log(sections);
-
-    sections.forEach(function (value) {
-      var option = domConstruct.create("option");
+    sortedSections.forEach(function (value) {
+      const option = domConstruct.create("option");
       option.text = value
       sectionSelect.add(option);
     });
   }
 
   const handleResults = results => {
-    if (results.features.length > 0) {
-      console.log(results);
-      
+    if (results.features.length > 0) {      
       return results;
-    } else {
-        console.log('reject!');
-        
-        var reason = new Error('This is an invalid Township-Range combination');
-        throw reason;
+    } else { 
+        throw new Error('This is an invalid Township-Range combination');;
     }
   }
 
@@ -987,7 +976,6 @@ require([
   on(townshipSelect, "change", function (evt) {
     resetElements(townshipSelect, false);
     var type = evt.target.value;
-    var i;
     
     if (rangeSelect.value !== "Zoom to a Range") { // check to see if combo is valid
       const rangeValue = rangeSelect.value;

--- a/script.js
+++ b/script.js
@@ -821,7 +821,6 @@ require([
   }
 
   function zoomToTRFeature(results) {
-    console.log(results.features);
     mapView.goTo(results.features);
     bufferLayer.graphics.removeAll();
     selectionLayer.graphics.removeAll();
@@ -947,8 +946,6 @@ require([
   // Add the unique values to the
   // section selection element.
   function buildSectionDropdown(values) {
-    console.log({values});
-    
     // remove sections
     for (j = sectionSelect.options.length - 1; j >= 0; j--) {
       sectionSelect.remove(j);
@@ -973,12 +970,22 @@ require([
     if (results.features.length > 0) {      
       return results;
     } else { 
+        $("#trs").prepend(
+          `<div id="TRSAlert" class="alert alert-danger" role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            Invalid Township-Range combination. Please enter a correct Township-Range combination.
+          </div>`
+        )
+        window.setTimeout(function() {
+          $("#TRSAlert").fadeTo(500, 0).slideUp(500, function(){
+              $(this).remove(); 
+          });
+      }, 4000);
         throw new Error('This is an invalid Township-Range combination');;
     }
   }
 
   function queryTR (type, whichDropdown) {
-    console.log({type, whichDropdown});
     if(whichDropdown === 'range') { 
       if (townshipSelect.value !== "Zoom to a Township") { // check to see if combo is valid
         const townshipValue = townshipSelect.value;

--- a/script.js
+++ b/script.js
@@ -1021,28 +1021,23 @@ require([
       }
     }
 
-  // when township changes, reset the other dropdowns.
+  // when township changes, reset the section dropdown and execute queryTR.
   on(townshipSelect, "change", function (evt) {
     resetElements(townshipSelect, false);
-    var type = evt.target.value;
-
+    const type = evt.target.value;
     queryTR(type, 'township');
-  
   });
 
-  // when range changes, reset the section dropdown.
+  // when range changes, reset the section dropdown and execute queryTR .
   on(rangeSelect, "change", function (evt) {
     resetElements(rangeSelect, false);
-    var type = evt.target.value;
-    var i;
-    
+    const type = evt.target.value;
     queryTR(type, 'range');
   });
 
-  var querySection = dom.byId("selectSection");
-  on(querySection, "change", function (e) {
+  on(sectionSelect, "change", function (e) {
     resetElements(sectionSelect, false);
-    var type = e.target.value;
+    const type = e.target.value;
     zoomToSectionFeature(townshipRangeSectionURL, type, "sec_ch");
   });
 

--- a/script.js
+++ b/script.js
@@ -991,7 +991,7 @@ require([
 
   function queryTR (type, whichDropdown) {
     if(whichDropdown === 'range') { 
-      if (townshipSelect.value !== "Zoom to a Township") { // check to see if combo is valid
+      if (townshipSelect.value !== "Zoom to a Township") { // check to see if combo is valid if populated
         const townshipValue = townshipSelect.value;
         const TRQuery = new Query({
           where: "rng_ch = '" + type.substr(0, 2) + "' AND rdir = '" + type.substr(2) + "' AND twn_ch = '" + townshipValue.substr(0, 2) + "' AND tdir = '" + townshipValue.substr(2) + "'",
@@ -1007,7 +1007,7 @@ require([
         });
       }
     } else if (whichDropdown === 'township') {
-        if (rangeSelect.value !== "Zoom to a Range") { // check to see if combo is valid
+        if (rangeSelect.value !== "Zoom to a Range") { // check to see if combo is valid if populated
           const rangeValue = rangeSelect.value;
           const TRQuery = new Query({
             where: "twn_ch = '" + type.substr(0, 2) + "' AND tdir = '" + type.substr(2) + "' AND rng_ch = '" + rangeValue.substr(0, 2) + "' AND rdir = '" + rangeValue.substr(2) + "'",

--- a/script.js
+++ b/script.js
@@ -998,7 +998,6 @@ require([
       const rangeValue = rangeSelect.value;
       const TRQuery = new Query({
         where: "twn_ch = '" + type.substr(0, 2) + "' AND tdir = '" + type.substr(2) + "' AND rng_ch = '" + rangeValue.substr(0, 2) + "' AND rdir = '" + rangeValue.substr(2) + "'",
-        // returnDistinctValues: true,
         returnGeometry: true
       });
       townshipRangeSectionLayer.queryFeatures(TRQuery)
@@ -1007,37 +1006,34 @@ require([
         console.log({results});
         zoomToTRFeature(results)
       })
-      // .then(results => unionGeometries(results))
       .catch((error) => {
         console.error(error);
       });
-      // .then(zoomToTRFeature(results)
-      // .then(handleResults(results)))
     }
-    // return townshipRangeSectionLayer.queryFeatures(rangeQuery).then(buildRangeDropdown);
   })
 
   // when range changes, reset the section dropdown.
   on(rangeSelect, "change", function (evt) {
     resetElements(rangeSelect, false);
     var type = evt.target.value;
-    var j;
-    // for (j = sectionSelect.options.length - 1; j >= 0; j--) {
-    //   sectionSelect.remove(j);
-    // }
-
-    // var e = document.getElementById("selectTownship");
-    // var strUser = e.options[e.selectedIndex].text;
-
-    // // TODO: Refactor this query to rmeove selectQuery.xxxxxxx    
-    // var selectQuery = new Query();
-    // selectQuery.where = "twn_ch = '" + strUser.substr(0, 2) + "' AND tdir = '" + strUser.substr(2) + "' AND rng_ch = '" + type.substr(0, 2) + "' AND rdir = '" + type.substr(2) + "' AND rng_ch <> ' '";
-    // selectQuery.outFields = ["sec_ch"];
-    // selectQuery.returnDistinctValues = true;
-    // selectQuery.orderByFields = ["sec_ch"];
-    // return townshipRangeSectionLayer.queryFeatures(selectQuery).then(buildSectionDropdown);
-
-
+    var i;
+    
+    if (townshipSelect.value !== "Zoom to a Township") { // check to see if combo is valid
+      const townshipValue = townshipSelect.value;
+      const TRQuery = new Query({
+        where: "rng_ch = '" + type.substr(0, 2) + "' AND rdir = '" + type.substr(2) + "' AND twn_ch = '" + townshipValue.substr(0, 2) + "' AND tdir = '" + townshipValue.substr(2) + "'",
+        returnGeometry: true
+      });
+      townshipRangeSectionLayer.queryFeatures(TRQuery)
+      .then(results => handleResults(results))
+      .then(results => {
+        console.log({results});
+        zoomToTRFeature(results)
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+    }
   });
 
   var querySection = dom.byId("selectSection");

--- a/script.js
+++ b/script.js
@@ -831,6 +831,7 @@ require([
       graphicArray.push(highlightGraphic);
     }
     selectionLayer.graphics.addMany(graphicArray);
+    return results;
   }
 
   //Input geometry, output buffer
@@ -948,32 +949,26 @@ require([
   // Add the unique values to the
   // section selection element.
   function buildSectionDropdown(values) {
+    console.log({values});
+    
     var option = domConstruct.create("option");
     option.text = "Zoom to a Section";
     sectionSelect.add(option);
 
-    values.features.forEach(function (value) {
+    sections = values.features
+
+    sections = sections.map(element => parseInt(element.attributes.sec_ch));
+    
+    console.log(sections);
+    sections = sections.sort((a, b) => a-b);
+    console.log(sections);
+
+    sections.forEach(function (value) {
       var option = domConstruct.create("option");
-      option.text = value.attributes.sec_ch;
+      option.text = value
       sectionSelect.add(option);
     });
   }
-
-  // function handleResults(results) {
-  //   new Promise(
-  //     function (resolve, reject) {
-  //         if (results) {
-  //           console.log(results);
-            
-  //           return Promise.resolve(results); // fulfilled
-  //           return results;
-  //         } else {
-  //             var reason = new Error('This is an invalid Township-Range combination');
-  //             reject(reason); // reject
-  //             throw reason;
-  //         }
-  //     });
-  // }
 
   const handleResults = results => {
     if (results.features.length > 0) {
@@ -998,14 +993,13 @@ require([
       const rangeValue = rangeSelect.value;
       const TRQuery = new Query({
         where: "twn_ch = '" + type.substr(0, 2) + "' AND tdir = '" + type.substr(2) + "' AND rng_ch = '" + rangeValue.substr(0, 2) + "' AND rdir = '" + rangeValue.substr(2) + "'",
+        outFields: ["*"], 
         returnGeometry: true
       });
       townshipRangeSectionLayer.queryFeatures(TRQuery)
       .then(results => handleResults(results))
-      .then(results => {
-        console.log({results});
-        zoomToTRFeature(results)
-      })
+      .then(results => zoomToTRFeature(results))
+      .then(results => buildSectionDropdown(results))
       .catch((error) => {
         console.error(error);
       });
@@ -1026,10 +1020,8 @@ require([
       });
       townshipRangeSectionLayer.queryFeatures(TRQuery)
       .then(results => handleResults(results))
-      .then(results => {
-        console.log({results});
-        zoomToTRFeature(results)
-      })
+      .then(results => zoomToTRFeature(results))
+      .then(results => buildSectionDropdown(results))
       .catch((error) => {
         console.error(error);
       });

--- a/script.js
+++ b/script.js
@@ -909,7 +909,7 @@ require([
       await buildTownshipDropdown(townshipResults);
       await buildRangeDropdown(rangeResults);
     } catch (err) {
-      console.log('Township load failed: ', err);
+      console.log('Township/Range load failed: ', err);
     }
   })
 

--- a/script.js
+++ b/script.js
@@ -916,10 +916,6 @@ require([
   // select element. This will allow the user
   // to filter states by subregion.
   function buildTownshipDropdown(values) {
-    var option = domConstruct.create("option");
-    option.text = "Zoom to a Township";
-    townshipSelect.add(option);
-
     values.features.forEach(function (value) {
       var option = domConstruct.create("option");
       var name = value.attributes.twn_ch + value.attributes.tdir;
@@ -931,10 +927,6 @@ require([
   // Add the unique values to the
   // range selection element.
   function buildRangeDropdown(values) {
-    var option = domConstruct.create("option");
-    option.text = "Zoom to a Range";
-    rangeSelect.add(option);
-
     values.features.forEach(function (value) {
       var option = domConstruct.create("option");
       var name = value.attributes.rng_ch + value.attributes.rdir;
@@ -947,10 +939,6 @@ require([
   // section selection element.
   function buildSectionDropdown(values) {
     sectionSelect.options.length = 0;
-
-    const option = domConstruct.create("option");
-    option.text = "Zoom to a Section";
-    sectionSelect.add(option);
     const sectionArr = values.features
     const sectionIntArr = sectionArr.map(element => element.attributes.sec_ch);
     const sortedSections = [...new Set(sectionIntArr)].sort();

--- a/script.js
+++ b/script.js
@@ -706,7 +706,13 @@ require([
     // find all dropdowns
     $("select").each(function () {
       if (trs) {
-        if ((this != currentElement) && (this != document.getElementById('selectLayerDropdown')) && (this != document.getElementById('selectTownship')) && (this != document.getElementById('selectRange')) && (this != document.getElementById('selectSection'))) {
+        if (
+          (this != currentElement) && 
+          (this != document.getElementById('selectLayerDropdown')) && 
+          (this != document.getElementById('selectTownship')) && 
+          (this != document.getElementById('selectRange')) && 
+          (this != document.getElementById('selectSection'))
+        ) {
             this.selectedIndex = 0
           }
         } else {


### PR DESCRIPTION
Fixing issue #131 

previously, county, city, quad dropdowns would not reset when selecting in the Township Range Section dropdowns. now, whenever Township, Range, Section dropdowns are selelected, all of the County, City, Quad dropdowns are reset. 


In addition, another bug was fixed in this where the bufferlayer wasn't being cleared correctly when choosing county, city, or quad after choosing a township, range, section combination