### PR TITLE
Feature/#167/coordinate identify highlight measure

### DIFF
--- a/infopanel.js
+++ b/infopanel.js
@@ -1,9 +1,6 @@
 function queryInfoPanel(results, i, event = false) {
     let count = results.length;
-    let removeThisResult = false;
-
-    console.log(results);
-    
+    let removeThisResult = false;    
 
     if (event.mapPoint) {
         $('#informationdiv').append('<p><a target="_blank" href=https://maps.google.com/maps?q=&layer=c&cbll=' + event.mapPoint.latitude + ',' + event.mapPoint.longitude + '>Google Street View&nbsp</a> <span class="esri-icon-description" data-toggle="tooltip" data-placement="top" title="Please note: if not clicked where there are streets, no imagery will be returned."></span><br><br></p>');

--- a/script.js
+++ b/script.js
@@ -2414,7 +2414,10 @@ require([
 
   var measureExpand = new Expand({
     view: mapView,
-    content: measurementToolbar
+    content: measurementToolbar,
+    expandIconClass: "esri-icon-measure-area",
+    expandTooltip: "Measurement Tools",
+    collapseTooltip: "Measurement Tools",
   });
 
   mapView.ui.add(measureExpand, "top-left");

--- a/script.js
+++ b/script.js
@@ -1116,7 +1116,7 @@ require([
     // when mapview is clicked:
     // clear graphics, check vis layers, identify layers
     on(mapView, "click", async function (event) {
-      if ((measurement.viewModel.state == "disabled")) {
+      if ((measurement.viewModel.state == "disabled") || (measurement.viewModel.state == "measured")) {
         if (screen.availWidth < 992) {
           identifyTaskFlow(event, false, true);
         } else {

--- a/script.js
+++ b/script.js
@@ -1137,7 +1137,6 @@ require([
 
 
   async function identifyTaskFlow(event, coordExpanParam, mobileView, geometry=false, eventType="click") {
-    console.log(event);
     if ((mapView.scale < minimumDrawScale) && (coordExpanParam || mobileView)) {
       document.getElementById("mapViewDiv").style.cursor = "wait";
       mapView.graphics.removeAll();
@@ -1149,7 +1148,6 @@ require([
       let layers = layerList.operationalItems.items
       // loop through layers
       for (layer of layers) {
-        console.log("for layer of layers");
         let visibleLayers;
         // exclude geographic names layer from identify operation
         if (layer.title !== 'Geographic Names') {
@@ -1158,15 +1156,11 @@ require([
           if (visibleLayers.length > 0) {
             if (layer.title === 'NGS Control Points') {
               const query = ngsLayer.createQuery();
-              if (geometry==false) {
-                console.log('geometry is false');
-                
+              if (geometry==false) {                
                 query.geometry = mapView.toMap(event);
                 query.distance = 30;
                 query.units = 'meters';
-              } else {
-                console.log('geometry is true');
-                
+              } else {                
                 query.geometry = event; 
               }
               query.returnGeometry = true;
@@ -1247,7 +1241,6 @@ require([
   }
 
   async function setIdentifyParameters(visibleLayers, eventType, event) {
-    console.log("setIdentifyParameters might be breaking");
     // receive array of active visible layer with urls
     // Set the parameters for the Identify
     params = new IdentifyParameters();
@@ -2456,57 +2449,29 @@ require([
   measurementIdentifyToggleButton.title = "Identify Measurement";
   measurementToolbar.appendChild(measurementIdentifyToggleButton)
 
-  // const identifyToggleButtonLabel = document.createElement("label");
-  // identifyToggleButtonLabel.className = "toggle-switch modifier-class";
-  // measurementToolbar.appendChild(identifyToggleButtonLabel)
-
-
-  // const identifyToggleButtonsSpan1 = document.createElement("span");
-  // identifyToggleButtonsSpan1.type = "checkbox";
-  // identifyToggleButtonsSpan1.className = "toggle-switch-input";
-  // identifyToggleButtonLabel.appendChild(identifyToggleButtonsSpan1);
-
-  // const identifyToggleButtonsSpan2 = document.createElement("span");
-  // identifyToggleButtonsSpan2.className = "toggle-switch-label font-size--1";
-  // identifyToggleButtonsSpan2.textContent = "Identify";
-  // identifyToggleButtonLabel.appendChild(identifyToggleButtonsSpan2);
-
   distanceButton.addEventListener("click", () => {
     distanceMeasurement();
     loadMeasurementWidget();
-    console.log({measurementDistance: measurement.viewModel.state})
   });
+
   areaButton.addEventListener("click", () => {
     areaMeasurement();
     loadMeasurementWidget();
-    console.log({measurementArea: measurement.viewModel.state})
-
   });
+
   clearButton.addEventListener("click", () => {
     clearMeasurements();
     loadMeasurementWidget();
     clearIdentifySelection();
-    console.log({measurementClear: measurement.viewModel.state});
   });
   measurementIdentifyToggleButton.addEventListener("click", () => {
-    // measurementIdentifyToggle();
-    // clearIdentifySelection();
-    MeasurementIdentify();
-  });
-
-  measurement.watch("viewModel", function(active) {
-    console.log(measurement);
-    console.log(active);
-
-    // if ((!active) && (measurementIdentifyToggleButton.classList.contains('esri-icon-checkbox-checked'))) {
-    //   MeasurementIdentify(); // need proper geometry
-    //   console.log(measurement);
-    // }
+    measurementIdentify();
   });
 
   function loadMeasurementWidget() {
     // Add the appropriate measurement UI to the bottom-right when activated
-    mapView.ui.add(measurement, "bottom-left");
+    mapView.ui.empty("bottom-left"); // remove the scalebar and any other bottom-left
+    mapView.ui.add([measurement, scaleBar], "bottom-left"); // add scalebar after measurement widget
   }
 
   // Call the appropriate DistanceMeasurement2D or DirectLineMeasurement3D
@@ -2516,7 +2481,6 @@ require([
       type.toUpperCase() === "2D" ? "distance" : "direct-line";
     distanceButton.classList.add("active");
     areaButton.classList.remove("active");
-    console.log(mapView);
   }
 
   // Call the appropriate AreaMeasurement2D or AreaMeasurement3D
@@ -2533,26 +2497,12 @@ require([
     measurement.clear();
   }
 
-  // Toggle identify Checkbox 
-  // function measurementIdentifyToggle() {
-  //   if (measurementIdentifyToggleButton.classList.contains('esri-icon-checkbox-checked')) {
-  //     measurementIdentifyToggleButton.classList.remove('esri-icon-checkbox-checked');
-  //     measurementIdentifyToggleButton.classList.add("esri-icon-checkbox-unchecked");
-  //   } else {
-  //     measurementIdentifyToggleButton.classList.remove('esri-icon-checkbox-unchecked');
-  //     measurementIdentifyToggleButton.classList.add('esri-icon-checkbox-checked');  
-  //   }
-  // }
-
-  function MeasurementIdentify() {
-    console.log(measurement);
-    // check if the identify toggle button is checked
-    // if checked, initiate the identify process
-    // if (measurementIdentifyToggleButton.classList.contains('esri-icon-checkbox-checked')) {
+  function measurementIdentify() {
+    // if measurement has finished, and the measurement tool is area measurement
+    // initiate identify
     if (measurement.viewModel.state == "measured" && measurement.activeTool == "area") {
       identifyTaskFlow(measurement.viewModel.activeViewModel.measurement.geometry, coordExpand.expanded !== true, false, true, "measurementIdentify");  // need to determine how to get geometry
     }
-    // }
   }
 
 });

--- a/script.js
+++ b/script.js
@@ -33,6 +33,7 @@ require([
   "esri/widgets/Expand",
   "esri/widgets/DistanceMeasurement2D",
   "esri/widgets/AreaMeasurement2D",
+  "esri/widgets/Measurement",
   "esri/core/watchUtils",
   "dojo/on",
   "dojo/dom",
@@ -85,6 +86,7 @@ require([
   Expand,
   DistanceMeasurement2D,
   AreaMeasurement2D,
+  Measurement,
   watchUtils, on, dom, domClass, domConstruct, domGeom, keys, JSON, query, Color,
   CalciteMapsArcGISSupport) {
 
@@ -2387,4 +2389,83 @@ require([
   // Clear Button
   var clearBtn = document.getElementById("clearButton");
   mapView.ui.add(clearBtn, "top-left");
+
+  const measurementToolbar = document.createElement("div")
+  measurementToolbar.id = "toolbar";
+  measurementToolbar.className =  "esri-component esri-widget";
+
+  var measureExpand = new Expand({
+    view: mapView,
+    content: measurementToolbar
+  });
+
+  mapView.ui.add(measureExpand, "top-left");
+
+
+  // Measurement Widget
+  const measurement = new Measurement({
+    view: mapView,
+    activeTool: "distance"
+  });
+  const distanceButton = document.createElement("button")
+  distanceButton.id = "distance";
+  distanceButton.className = "esri-widget--button esri-interactive esri-icon-measure-line";
+  distanceButton.title = "Distance Measurement Tool";
+  measurementToolbar.appendChild(distanceButton)
+  
+  const areaButton = document.createElement("button")
+  areaButton.id = "area";
+  areaButton.className = "esri-widget--button esri-interactive esri-icon-measure-area";
+  areaButton.title = "Area Measurement Tool";
+  measurementToolbar.appendChild(areaButton)
+
+  const clearButton = document.createElement("button")
+  clearButton.id = "clear";
+  clearButton.className = "esri-widget--button esri-interactive esri-icon-trash";
+  clearButton.title = "Clear Measurements";
+  measurementToolbar.appendChild(clearButton)
+
+
+  distanceButton.addEventListener("click", function () {
+    distanceMeasurement();
+    loadMeasurementWidget();
+  });
+  areaButton.addEventListener("click", function () {
+    areaMeasurement();
+    loadMeasurementWidget();
+  });
+  clearButton.addEventListener("click", function () {
+    clearMeasurements();
+    loadMeasurementWidget();
+  });
+
+  function loadMeasurementWidget() {
+    // Add the appropriate measurement UI to the bottom-right when activated
+    mapView.ui.add(measurement, "bottom-right");
+  }
+
+  // Call the appropriate DistanceMeasurement2D or DirectLineMeasurement3D
+  function distanceMeasurement() {
+    const type = mapView.type;
+    measurement.activeTool =
+      type.toUpperCase() === "2D" ? "distance" : "direct-line";
+    distanceButton.classList.add("active");
+    areaButton.classList.remove("active");
+    console.log(mapView);
+  }
+
+  // Call the appropriate AreaMeasurement2D or AreaMeasurement3D
+  function areaMeasurement() {
+    measurement.activeTool = "area";
+    distanceButton.classList.remove("active");
+    areaButton.classList.add("active");
+  }
+
+  // Clears all measurements
+  function clearMeasurements() {
+    distanceButton.classList.remove("active");
+    areaButton.classList.remove("active");
+    measurement.clear();
+  }
+
 });

--- a/script.js
+++ b/script.js
@@ -2407,23 +2407,58 @@ require([
     view: mapView,
     activeTool: "distance"
   });
-  const distanceButton = document.createElement("button")
+  const distanceButton = document.createElement("button");
   distanceButton.id = "distance";
   distanceButton.className = "esri-widget--button esri-interactive esri-icon-measure-line";
   distanceButton.title = "Distance Measurement Tool";
   measurementToolbar.appendChild(distanceButton)
   
-  const areaButton = document.createElement("button")
+  const areaButton = document.createElement("button");
   areaButton.id = "area";
   areaButton.className = "esri-widget--button esri-interactive esri-icon-measure-area";
   areaButton.title = "Area Measurement Tool";
   measurementToolbar.appendChild(areaButton)
 
-  const clearButton = document.createElement("button")
+  const clearButton = document.createElement("button");
   clearButton.id = "clear";
   clearButton.className = "esri-widget--button esri-interactive esri-icon-trash";
   clearButton.title = "Clear Measurements";
-  measurementToolbar.appendChild(clearButton)
+  measurementToolbar.appendChild(clearButton);
+
+  const measurementIdentifyToggleButton = document.createElement("button");
+  measurementIdentifyToggleButton.id = "identifyMeasurement";
+  measurementIdentifyToggleButton.className = "esri-widget--button esri-interactive esri-icon-checkbox-checked";
+  measurementIdentifyToggleButton.title = "Identify Measurement";
+  measurementToolbar.appendChild(measurementIdentifyToggleButton)
+
+// <div class="btn-group-toggle" data-toggle="buttons">
+//   <label class="btn btn-secondary active">
+//   <input type="checkbox" checked autocomplete="off"> Checked
+// </label>
+// </div>
+
+
+  // const measurementIdentifyToggleButton = document.createElement("button");
+  // clearButton.id = "measurementIdentifyToggleButton";
+  // clearButton.className = "esri-widget--button esri-interactive esri-icon-trash";
+  // clearButton.title = "Clear Measurements";
+  // measurementToolbar.appendChild(clearButton)
+
+  const identifyToggleButtonLabel = document.createElement("label");
+  identifyToggleButtonLabel.className = "toggle-switch modifier-class";
+  measurementToolbar.appendChild(identifyToggleButtonLabel)
+
+
+  const identifyToggleButtonsSpan1 = document.createElement("span");
+  identifyToggleButtonsSpan1.type = "checkbox";
+  identifyToggleButtonsSpan1.className = "toggle-switch-input";
+  identifyToggleButtonLabel.appendChild(identifyToggleButtonsSpan1);
+
+  const identifyToggleButtonsSpan2 = document.createElement("span");
+  identifyToggleButtonsSpan2.className = "toggle-switch-label font-size--1";
+  identifyToggleButtonsSpan2.textContent = "Identify";
+  identifyToggleButtonLabel.appendChild(identifyToggleButtonsSpan2);
+  
 
 
   distanceButton.addEventListener("click", function () {
@@ -2437,6 +2472,9 @@ require([
   clearButton.addEventListener("click", function () {
     clearMeasurements();
     loadMeasurementWidget();
+  });
+  measurementIdentifyToggleButton.addEventListener("click", function () {
+    measurementIdentifyToggle();
   });
 
   function loadMeasurementWidget() {
@@ -2466,6 +2504,17 @@ require([
     distanceButton.classList.remove("active");
     areaButton.classList.remove("active");
     measurement.clear();
+  }
+
+  // Toggle identify Checkbox 
+  function measurementIdentifyToggle() {
+    if (measurementIdentifyToggleButton.classList.contains('esri-icon-checkbox-checked')) {
+      measurementIdentifyToggleButton.classList.remove('esri-icon-checkbox-checked');
+      measurementIdentifyToggleButton.classList.add("esri-icon-checkbox-unchecked");
+    } else {
+      measurementIdentifyToggleButton.classList.remove('esri-icon-checkbox-unchecked');
+      measurementIdentifyToggleButton.classList.add('esri-icon-checkbox-checked');  
+    }
   }
 
 });

--- a/script.js
+++ b/script.js
@@ -1118,9 +1118,9 @@ require([
     on(mapView, "click", async function (event) {
       if ((measurement.viewModel.state == "disabled") || (measurement.viewModel.state == "measured")) {
         if (screen.availWidth < 992) {
-          identifyTaskFlow(event, false, true);
+          identifyTaskFlow(event, false, true, false, "click");
         } else {
-          identifyTaskFlow(event, coordExpand.expanded !== true, false);
+          identifyTaskFlow(event, coordExpand.expanded == false, false, false, "click");
         }
       }
     });
@@ -1135,9 +1135,24 @@ require([
     $('#infoSpan').html('Information Panel');
   }
 
+  function checkScale(eventType, coordExpanParam, mobileView) {
+    // check the scale, unless the identifyTask originated from a measurementIdenty
+    // if from measurementIdenty, return true
+
+    if (eventType == "click") {
+      if ((mapView.scale < minimumDrawScale) && (coordExpanParam || mobileView)) {
+        return true;
+      }
+    } else if ((eventType == "measurementIdentify") && (coordExpanParam || mobileView)) { // allow measurement identify to trigger at any scale
+      return true;
+    }
+    // either not the right scale or 
+    return false;
+  }
+
 
   async function identifyTaskFlow(event, coordExpanParam, mobileView, geometry=false, eventType="click") {
-    if ((mapView.scale < minimumDrawScale) && (coordExpanParam || mobileView)) {
+    if (checkScale(eventType, coordExpanParam, mobileView) == true) { // check if scale is where map features are visible or measurementIdentify
       document.getElementById("mapViewDiv").style.cursor = "wait";
       mapView.graphics.removeAll();
       selectionLayer.graphics.removeAll();
@@ -1199,7 +1214,7 @@ require([
         $('#infoSpan').html('Information Panel - 0 features found.');
         $('#informationdiv').append('<p>This query did not return any features</p>');
       }
-    }
+    } 
     document.getElementById("mapViewDiv").style.cursor = "auto";
   }
 
@@ -1240,7 +1255,7 @@ require([
     return visibleLayerIds;
   }
 
-  async function setIdentifyParameters(visibleLayers, eventType, event) {
+  async function setIdentifyParameters(visibleLayers, eventType, event) {    
     // receive array of active visible layer with urls
     // Set the parameters for the Identify
     params = new IdentifyParameters();

--- a/script.js
+++ b/script.js
@@ -2506,7 +2506,7 @@ require([
 
   function loadMeasurementWidget() {
     // Add the appropriate measurement UI to the bottom-right when activated
-    mapView.ui.add(measurement, "bottom-right");
+    mapView.ui.add(measurement, "bottom-left");
   }
 
   // Call the appropriate DistanceMeasurement2D or DirectLineMeasurement3D

--- a/styles.css
+++ b/styles.css
@@ -127,6 +127,16 @@ body,
   padding: 8px;
 }
 
+#toolbarDiv {
+  /* position: absolute; */
+  /* top: 100px; */
+  /* right: 100px; */
+  cursor: default;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+}
+
 @media only screen and (max-width: 1026px) {
   #overviewDiv {
     display: none;


### PR DESCRIPTION
In preparation for customer request to have measurement functionality put into the new LABINS map.

This work allows the user to:
- complete distance or area measurement
- clear measurements with either the eraser clear button or trashcan clear button (this could be combined to just 1 clear button though because they essentially do the same thing)
- complete an identify after an area measurement is performed

shortcomings/room for improvement:
- allow the user to complete multiple measurements while also preserving graphics for later. 