### PR TITLE
#167 clear measurements when measureExpand is collapsed

### DIFF
--- a/script.js
+++ b/script.js
@@ -2467,6 +2467,12 @@ require([
   measurementIdentifyToggleButton.title = "Identify Measurement";
   measurementToolbar.appendChild(measurementIdentifyToggleButton)
 
+  measureExpand.watch("expanded", function() {
+    if (measureExpand.expanded == false) {
+      clearMeasurements();
+    }
+  });
+
   distanceButton.addEventListener("click", () => {
     distanceMeasurement();
     loadMeasurementWidget();

--- a/styles.css
+++ b/styles.css
@@ -469,3 +469,7 @@ h3.esri-widget__heading {
   background: #0079c1;
   color: #e4e4e4;
 }
+.esri-distance-measurement-2d__hint-text::after {
+  display: block;
+  content: "End by double clicking";
+}


### PR DESCRIPTION
A little more testing needed, but this watches for the measureExpand to collapse. If it is collapsed, it executes clearMeasurements()


By using [watch()](https://developers.arcgis.com/javascript/latest/api-reference/esri-core-Accessor.html#watch), you can see when any property of any widget (or anything else really) changes. It could be useful in a lot of other places where we have event listeners