### PR TITLE
#171/upgrade jsapi

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Calcite Maps -->
   <link rel="stylesheet" href="https://esri.github.io/calcite-maps/dist/css/calcite-maps-arcgis-4.x.min-v0.8.css">
   <!-- ArcGIS JS 4 -->
-  <link rel="stylesheet" href="https://js.arcgis.com/4.15/esri/css/main.css">
+  <link rel="stylesheet" href="https://js.arcgis.com/4.18/esri/css/main.css">
   <link rel="stylesheet" href="styles.css">
   <!-- jQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
@@ -378,7 +378,7 @@
     };
   </script>
   <!-- ArcGIS JS 4 -->
-  <script src="https://js.arcgis.com/4.15/"></script>
+  <script src="https://js.arcgis.com/4.18/"></script>
   <!-- Parcel Information Templates -->
   <script src="infopanel.js"></script>
   <!-- Main script-->

--- a/script.js
+++ b/script.js
@@ -149,9 +149,6 @@ require([
 
     const customRenderer = {
       type: "unique-value",
-      // field: "pos_srce",
-      // field2: "vert_srce",
-      // fieldDelimiter: ",",
       uniqueValueInfos: buildValueInfos(),
       defaultSymbol: default_symbol,
       defaultLabel: 'Unknown',


### PR DESCRIPTION
Unable to find any bugs by swapping to 4.18. Looks like that renderer code was all that was breaking things. 