### PR TITLE
#198 refactor clear button

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,9 +108,6 @@
   <!-- Map  -->
   <div class="calcite-map calcite-map-absolute">
       <div id="mapViewDiv"></div>
-      <button title="Clear graphics" type="button" class="btn btn-default" id="clearButton">
-        <span class="esri-icon-erase"></span>
-      </button>
   </div>
   <div id="overviewDiv">
     <div id="extentDiv"></div>

--- a/script.js
+++ b/script.js
@@ -2112,16 +2112,6 @@ require([
     mapView.map.basemap = e.target.value;
   });
 
-  // Clear all graphics from map  
-  on(dom.byId("clearButton"), "click", function (evt) {
-    mapView.graphics.removeAll();
-    selectionLayer.graphics.removeAll();
-    bufferLayer.graphics.removeAll();
-    clearDiv('informationdiv');
-    $('#numinput').val('');
-    $('#infoSpan').html('Information Panel');
-  });
-
   // after a query typed into search bar
   searchWidget.on("search-complete", async function (event) {
     infoPanelData = [];
@@ -2588,7 +2578,20 @@ require([
   mapView.ui.add(locateBtn, "top-left");
 
   // Clear Button
-  var clearBtn = document.getElementById("clearButton");
+  const clearBtn = document.createElement("div");
+  clearBtn.id = "clearButton";
+  clearBtn.className = "esri-widget--button esri-interactive esri-icon-erase";
+
+  // Clear all graphics from map  
+  clearBtn.addEventListener("click", () => {
+    mapView.graphics.removeAll();
+    selectionLayer.graphics.removeAll();
+    bufferLayer.graphics.removeAll();
+    clearDiv('informationdiv');
+    $('#numinput').val('');
+    $('#infoSpan').html('Information Panel');
+  });
+
   mapView.ui.add(clearBtn, "top-left");
 
   // measurement needs to be defined here or else it won't be in global scope

--- a/styles.css
+++ b/styles.css
@@ -29,15 +29,6 @@ body,
   font-size: 14px;
 }
 
-.esri-icon-erase {
-  position: absolute;
-
-  transform: translate(-50%, -50%);
-  width: 8px;
-  height: 16px;
-  display: block;
-}
-
 /* color of label toggle button */
 .esri-layer-list__item-actions-menu-item:first-of-type {
   color: lightgray;


### PR DESCRIPTION
Button now loads with the rest of the map, is centered, and matches the styling of the rest of the buttons. Functionality is unchanged. 